### PR TITLE
Upgraded to Spectre 0.45

### DIFF
--- a/src/sample-cli/spectre-fs-sample-cli.fsproj
+++ b/src/sample-cli/spectre-fs-sample-cli.fsproj
@@ -15,7 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.44.0" />
+    <PackageReference Include="Spectre.Console" Version="0.45.0" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/spectre-fs/spectre-fs.fsproj
+++ b/src/spectre-fs/spectre-fs.fsproj
@@ -11,6 +11,6 @@
     <Compile Include="Rule.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.44.0" />
+    <PackageReference Include="Spectre.Console" Version="0.45.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Release notes for the new version can be found [here](https://spectreconsole.net/blog/posts/2022-09-10-spectre-console-0.45-released).