### PR TITLE
Feature/add renderable payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ MarkupCS (Color.Red, Bold, "Hello [World]") |> toConsole
 #### Payloads
 The following table lists all payloads currently available:
 
-| Type         | Short | Description                                | Parameters                                    | Configurbility |
+| Type         | Alias | Description                                | Parameters                                    | Configurbility |
 | ------------ | ----- | ------------------------------------------ | --------------------------------------------- | -------------- |
 | MarkupS      | MS    | Content marked up with a style             | style: `SpectreCoff.Layout.Style`<br /> content: `string`                              | -              |
 | MarkupC      | MC    | Content marked up with a style             | color: `Spectre.Console.Color`<br /> content: `string`                             | -              |
@@ -91,6 +91,7 @@ The following table lists all payloads currently available:
 | Newline      | NL    | An empty line                              | - | -
 | Many         | -     | Prints many lines at once, in the calm style | items: list of `string` | (indirectly via the calm style) 
 | ManyMarkedUp | -     | Prints many payloads at once, each on own line | items: list of `OutputPayload` | -
+| Renderable   | -     | Wraps a Spectre.Rendering.IRenderable | content: `Spectre.Rendering.IRenderable` | -
 
 
 #### Convenience Styles

--- a/README.md
+++ b/README.md
@@ -89,10 +89,8 @@ The following table lists all payloads currently available:
 | Emoji        | -     | An emoji, given by it's string literal | emoji: `string` | -
 | BulletItems  | BI    | Show list of items with bullet points      | items: list of `OutputPayload` | bullet item prefix: `Output.bulletItemPrefix`
 | Newline      | NL    | An empty line                              | - | -
-| Many         | -     | Prints many lines at once, in the calm style | items: list of `string` | (indirectly via the calm style) 
-| ManyMarkedUp | -     | Prints many payloads at once, each on own line | items: list of `OutputPayload` | -
+| Many         | -     | Prints many payloads at once, each on own line | items: list of `OutputPayload` | -
 | Renderable   | -     | Wraps a Spectre.Rendering.IRenderable | content: `Spectre.Rendering.IRenderable` | -
-
 
 #### Convenience Styles
 The table above lists three convenience styles: `Calm`, `Pumped` and `Edgy`. With these, we can easily provide a consistent, and semantically meaningful, styling across the modules:

--- a/src/spectrecoff-cli/commands/BarChart.fs
+++ b/src/spectrecoff-cli/commands/BarChart.fs
@@ -24,7 +24,7 @@ type BarChartExample() =
             ChartItem ("Peach", 6)
             ChartItemWithColor ("White", 2, Color.White)
         ]
-        alignment <- Alignment.Left
+        alignment <- Left
 
         items
         |> barChart "Fruits"

--- a/src/spectrecoff-cli/commands/Figlet.fs
+++ b/src/spectrecoff-cli/commands/Figlet.fs
@@ -38,7 +38,7 @@ type FigletDocumentation() =
         |> SpectreCoff.Rule.alignedRule Left 
         |> SpectreCoff.Rule.toConsole
         
-        ManyMarkedUp [
+        Many [
             CO [
                 C "This module provides functionality from the figlet widget of Spectre.Console ("
                 Link "https://spectreconsole.net/widgets/figlet"

--- a/src/spectrecoff-cli/commands/Figlet.fs
+++ b/src/spectrecoff-cli/commands/Figlet.fs
@@ -52,8 +52,8 @@ type FigletDocumentation() =
             NL
             C "This figlet will use the"
             BI [
-                CO [P "Figlet.defaultAlignment"; C ", initialized to "; P "Center"; C ", and"]
-                CO [P "Figlet.defaultColor"; C ", initialized to the pumped color "; P "Output.pumpedColor"; C ","]
+                CO [P "Figlet.defaultAlignment,"; C "initialized to"; P "Center,"; C "and"]
+                CO [P "Figlet.defaultColor,"; C "initialized to the pumped color"; P "Output.pumpedColor"; C ","]
             ]
             C "which both can be modified."
             NL
@@ -62,7 +62,7 @@ type FigletDocumentation() =
                 P "customFiglet: Alignment -> Color -> string -> FigletText"
             ]
             NL
-            CO [C "The figlet can be printed to the console with the "; P "toConsole"; C " function."]
+            CO [C "The figlet can be printed to the console with the"; P "toConsole"; C "function."]
             NL
         ] |> toConsole
         0

--- a/src/spectrecoff-cli/commands/Output.fs
+++ b/src/spectrecoff-cli/commands/Output.fs
@@ -67,9 +67,9 @@ type OutputExample() =
             P "That is the motivation for the short"
             E "No need to escape markup characters from strings [ ... /] manually."
             CO [
-                C "The CO type can be used to print ";
-                P "multiple marked up pieces";
-                E " in one line, too."
+                C "The CO type can be used to print"; 
+                P "multiple marked up pieces"; 
+                E "in one line, too." 
             ]
             NewLine
         ] |> toConsole
@@ -77,15 +77,15 @@ type OutputExample() =
         // There are special payloads for links and emojis:
         ManyMarkedUp [
             CO [
-                C "You can easily render clickable links: "
+                C "You can easily render clickable links:"
                 Link "https://www.spectreconsole.net/markup"
             ]
             CO [
-                C "You can add a label as well: "
+                C "You can add a label as well:"
                 LinkWithLabel ("See documentation!", "https://www.spectreconsole.net/markup")
             ]
             CO [
-                C "You can also use emojis by their string literals "
+                C "You can also use emojis by their string literals"
                 Emoji "alien_monster"
             ]
             C $"""or use the constants provided by Spectre {Emoji.Known.Ghost} inline."""

--- a/src/spectrecoff-cli/commands/Output.fs
+++ b/src/spectrecoff-cli/commands/Output.fs
@@ -51,56 +51,52 @@ type OutputExample() =
         NewLine |> toConsole
 
         // You can print multiple lines at once very easily as well:
-        Many [
+        [
             "Sometimes you"
             "Just want to"
             "Write a decent text"
             "Without being bothered by"
             "Symbols, types and other things ... "
-        ] |> toConsole
-        NewLine |> toConsole
+        ] 
+        |> List.map Calm
+        |> Many
+        |> toConsole
 
-        // You can markup each of the lines individually:
-        ManyMarkedUp [
-            C "You can print many marked up lines easily as well."
+        // You can markup each of the lines individually, and compose with any kind of payload:
+        Many [
             NewLine
-            P "That is the motivation for the short"
-            E "No need to escape markup characters from strings [ ... /] manually."
+            C "You can print many marked up lines easily as well."
+            P "That is the motivation for the short alias."
+            E "It preserves indentation and let's you focus on the content."
+            NewLine
             CO [
                 C "The CO type can be used to print"; 
                 P "multiple marked up pieces"; 
                 E "in one line, too." 
             ]
             NewLine
-        ] |> toConsole
-
-        // There are special payloads for links and emojis:
-        ManyMarkedUp [
-            CO [
-                C "You can easily render clickable links:"
-                Link "https://www.spectreconsole.net/markup"
-            ]
-            CO [
-                C "You can add a label as well:"
-                LinkWithLabel ("See documentation!", "https://www.spectreconsole.net/markup")
-            ]
-            CO [
-                C "You can also use emojis by their string literals"
-                Emoji "alien_monster"
-            ]
-            C $"""or use the constants provided by Spectre {Emoji.Known.Ghost} inline."""
-            NewLine
-        ] |> toConsole
-
-        // You can also easily print bullet items:
-        bulletItemPrefix <- "  ->> "
-        ManyMarkedUp [
-            C "Another common use-case is: "
+            C "Or, if you want to list a few items you can use BulletItems: "
             BulletItems [
                 C "listing"
                 P "several"
                 E "items"
             ]
+            NewLine
+            CO [
+                C "You can easily render clickable links:"
+                Link "https://www.spectreconsole.net/markup"
+            ]
+            CO [
+                C "Even with a dedicated display test:"
+                LinkWithLabel ("See documentation!", "https://www.spectreconsole.net/markup")
+            ]
+            NewLine
+            CO [
+                C "You can use emojis by their string literals"
+                Emoji "alien_monster"
+            ]
+            C $"""or use the constants provided by Spectre {Emoji.Known.Ghost} inline."""
+            NewLine
         ] |> toConsole
         0
 

--- a/src/spectrecoff-cli/commands/Progress.fs
+++ b/src/spectrecoff-cli/commands/Progress.fs
@@ -32,9 +32,9 @@ type Progress() =
             ChartItemWithColor ("CanvasImage", 0, Color.Red)
             ChartItemWithColor ("TextPath", 0, Color.Red)
         ]
-        alignment <- Alignment.Left
+        alignment <- Left
 
-        ManyMarkedUp [
+        Many [
             NewLine
             C "Below, a breakdown of our progress porting Spectre.Console modules to SpectreCoff:"
             NewLine

--- a/src/spectrecoff-cli/commands/Prompt.fs
+++ b/src/spectrecoff-cli/commands/Prompt.fs
@@ -37,7 +37,7 @@ type PromptDocumentation() =
         |> alignedRule Left 
         |> SpectreCoff.Rule.toConsole
         
-        ManyMarkedUp [
+        Many [
             CO [
                 C "This module provides functionality from the prompts of Spectre.Console ("
                 Link "https://spectreconsole.net/prompts"

--- a/src/spectrecoff-cli/commands/Prompt.fs
+++ b/src/spectrecoff-cli/commands/Prompt.fs
@@ -43,7 +43,7 @@ type PromptDocumentation() =
                 Link "https://spectreconsole.net/prompts"
                 C ")"
             ]
-            CO [C "This module provides functionality from the "; E "prompt"; C " of Spectre.Console"]
+            CO [C "This module provides functionality from the"; E "prompt"; C "of Spectre.Console"]
             NL
             C "Currently, we expose two basic functionalities:"
             BI [ 

--- a/src/spectrecoff-cli/commands/Rule.fs
+++ b/src/spectrecoff-cli/commands/Rule.fs
@@ -54,14 +54,14 @@ type RuleDocumentation() =
                 P "rule: string -> Rule"
             ]
             NL
-            CO [C "This rule will use the "; P "Rule.defaultAlignment"; C ", which is set to "; P "Center"; C " but can be modified."]
+            CO [C "This rule will use the"; P "Rule.defaultAlignment,"; C "which is set to"; P "Center"; C "but can be modified."]
             NL
             C "Other rules can be used without changing the default by passing in the alignment as an argument to: "
             BI [ 
                 P "alignedRule: Alignment -> string -> Rule"
             ]
             NL
-            CO [C "The rule can be printed to the console with the "; P "toConsole"; C " function."]
+            CO [C "The rule can be printed to the console with the"; P "toConsole"; C "function."]
             NL
         ] |> toConsole
         0

--- a/src/spectrecoff-cli/commands/Rule.fs
+++ b/src/spectrecoff-cli/commands/Rule.fs
@@ -42,7 +42,7 @@ type RuleDocumentation() =
         |> alignedRule Left 
         |> SpectreCoff.Rule.toConsole
         
-        ManyMarkedUp [
+        Many [
             CO [
                 C "This module provides functionality from the rule widget of Spectre.Console ("
                 Link "https://spectreconsole.net/widgets/rule"

--- a/src/spectrecoff-cli/commands/Table.fs
+++ b/src/spectrecoff-cli/commands/Table.fs
@@ -40,7 +40,7 @@ type TableExample() =
         let exampleMarkup = 
             "some text" 
             |> markupString (Some Color.Red) (Some Bold)
-            |> toMarkup
+            |> Markup
 
         [ Renderables [ exampleTable;  exampleMarkup ]
           Payloads [ P "Let's"; E " Go!" ] ] 

--- a/src/spectrecoff-cli/commands/Table.fs
+++ b/src/spectrecoff-cli/commands/Table.fs
@@ -43,7 +43,7 @@ type TableExample() =
             |> Markup
 
         [ Renderables [ exampleTable;  exampleMarkup ]
-          Payloads [ P "Let's"; E " Go!" ] ] 
+          Payloads [ P "Let's"; E "Go!" ] ] 
             |> table headers 
             |> SpectreCoff.Table.toConsole
 

--- a/src/spectrecoff/Output.fs
+++ b/src/spectrecoff/Output.fs
@@ -78,8 +78,7 @@ type OutputPayload =
     | Collection of OutputPayload list
     | BulletItems of OutputPayload list
     | NewLine
-    | Many of string list
-    | ManyMarkedUp of OutputPayload list
+    | Many of OutputPayload list
     | Renderable of Rendering.IRenderable
 
 // Short aliases
@@ -120,10 +119,7 @@ let rec toMarkedUpString (payload: OutputPayload) =
             | _ -> CO [C bulletItemPrefix; item])
         |> List.map toMarkedUpString
         |> joinSeparatedByNewline
-    | Many strings -> 
-        strings
-        |> joinSeparatedByNewline
-    | ManyMarkedUp payloads -> 
+    | Many payloads -> 
         payloads
         |> List.map toMarkedUpString
         |> joinSeparatedByNewline

--- a/src/spectrecoff/Table.fs
+++ b/src/spectrecoff/Table.fs
@@ -57,9 +57,9 @@ let private applyLayout (layout: ColumnLayout) (column : TableColumn) =
 
 let private toSpectreContentColumn (content: HeaderContent) =
     match content with
-    | Simple value -> TableColumn(value)
-    | Renderable renderable -> TableColumn(renderable)
-    | Payload renderable -> TableColumn(renderable |> toRenderablePayload)
+    | Simple value -> TableColumn(value) 
+    | Renderable renderable -> TableColumn(renderable) 
+    | Payload renderable -> TableColumn(renderable |> payloadToRenderable)
 
 let private toSpectreColumn (header: Header) =
     match header with
@@ -72,7 +72,7 @@ let addRow (table: Table) (row: Row) =
         | Renderables renderables -> renderables
         | Strings values -> values |> List.map (fun value -> Text value)
         | Numbers values -> values |> List.map (fun value -> Text (value.ToString()))
-        | Payloads payloads -> payloads |> List.map (fun payload -> toRenderablePayload payload)
+        | Payloads payloads -> payloads |> List.map (fun payload -> payloadToRenderable payload)
 
     table.AddRow(values) |> ignore
 
@@ -103,6 +103,6 @@ let customTable (layout: TableLayout) (headers: Header list) (rows: Row list) =
 let table =
     customTable defaultTableLayout
 
-let toConsole (table: Table) =
+// Output methods
+let toConsole (table: Table) = 
     table |> AnsiConsole.Write
-


### PR DESCRIPTION
Check it out, streamlined output and extended it by renderable.

No breaking change, except no need for spaces anymore in collections:
 `CO [P "Hi"; E "Daniel"]` will now automatically separate by spaces.
