### PR TITLE
Feature/remove to console from modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ pumpedColor <- Color.Yellow
 pumpedStyle <- Style.Italic
 ```
 
-#### Composite Payloads
+#### Composition of Payloads
 Some of the payloads listed above in turn accept payloads as arguments. Composing them in this way allows printing more complex content, as well as aggregating all output in one go before printing it. This can be seen in this example,
 ```Fs
-ManyMarkedUp [
+Many [
     MarkupC (Color.Green, "Hello friends,")
     Newline    
     Pumped "Welcome to my party tomorrow night!"
@@ -121,6 +121,8 @@ ManyMarkedUp [
     CO [C "See you "; P "later ... "]                 // short for Collection
 ] |> toConsole
 ``` 
+In fact, _any other payload_ can be composed using `Many` (including others of type `Many`, they will be flattened) and will be printed once `toConsole` is called.
+
 These composites are also the motivation for the short aliases of payloads, as these make it possible to focuis on the content and not be distracted too much by the types.
 For more examples, please see the [sample command](https://github.com/EluciusFTW/SpectreCoff/blob/main/src/spectrecoff-cli/commands/Output.fs).
 

--- a/src/spectrecoff-cli/commands/BarChart.fs
+++ b/src/spectrecoff-cli/commands/BarChart.fs
@@ -5,6 +5,7 @@ open Spectre.Console.Cli
 open SpectreCoff.BarChart
 open SpectreCoff.Cli
 open SpectreCoff.Layout
+open SpectreCoff.Output
 
 type BarChartSettings() =
     inherit CommandSettings()

--- a/src/spectrecoff-cli/commands/Figlet.fs
+++ b/src/spectrecoff-cli/commands/Figlet.fs
@@ -5,6 +5,7 @@ open Spectre.Console
 
 open SpectreCoff.Layout
 open SpectreCoff.Figlet
+open SpectreCoff.Output
 
 type FigletSettings()  =
     inherit CommandSettings()
@@ -60,7 +61,7 @@ type FigletDocumentation() =
             NL
             C "Other rules can be used without changing the default by passing in the alignment as an argument to: "
             BI [ 
-                P "customFiglet: Alignment -> Color -> string -> FigletText"
+                P "customFiglet: Alignment -> Color -> string -> Renderable"
             ]
             NL
             CO [C "The figlet can be printed to the console with the"; P "toConsole"; C "function."]

--- a/src/spectrecoff-cli/commands/Figlet.fs
+++ b/src/spectrecoff-cli/commands/Figlet.fs
@@ -25,6 +25,7 @@ type FigletExample() =
 
 open SpectreCoff.Cli
 open SpectreCoff.Output
+open SpectreCoff.Rule
 
 type FigletDocumentation() =
     inherit Command<FigletSettings>()
@@ -35,8 +36,8 @@ type FigletDocumentation() =
 
         NewLine |> toConsole
         pumped "Figlet module"
-        |> SpectreCoff.Rule.alignedRule Left 
-        |> SpectreCoff.Rule.toConsole
+        |> alignedRule Left 
+        |> toConsole
         
         Many [
             CO [
@@ -44,7 +45,7 @@ type FigletDocumentation() =
                 Link "https://spectreconsole.net/widgets/figlet"
                 C ")"
             ]
-            NewLine
+            NL
             C "The figlet can be used by the figlet function:"
             BI [ 
                 P "figlet: string -> FigletText"
@@ -63,6 +64,5 @@ type FigletDocumentation() =
             ]
             NL
             CO [C "The figlet can be printed to the console with the"; P "toConsole"; C "function."]
-            NL
         ] |> toConsole
         0

--- a/src/spectrecoff-cli/commands/Output.fs
+++ b/src/spectrecoff-cli/commands/Output.fs
@@ -81,7 +81,7 @@ type OutputExample() =
                 P "several"
                 E "items"
             ]
-            NewLine
+            SpectreCoff.Rule.rule "Links  and Emojis"
             CO [
                 C "You can easily render clickable links:"
                 Link "https://www.spectreconsole.net/markup"

--- a/src/spectrecoff-cli/commands/Output.fs
+++ b/src/spectrecoff-cli/commands/Output.fs
@@ -81,7 +81,7 @@ type OutputExample() =
                 P "several"
                 E "items"
             ]
-            SpectreCoff.Rule.rule "Links  and Emojis"
+            SpectreCoff.Rule.rule "Links and Emojis"
             CO [
                 C "You can easily render clickable links:"
                 Link "https://www.spectreconsole.net/markup"

--- a/src/spectrecoff-cli/commands/Panel.fs
+++ b/src/spectrecoff-cli/commands/Panel.fs
@@ -3,6 +3,7 @@ namespace SpectreCoff.Cli.Commands
 open Spectre.Console.Cli
 open SpectreCoff.Panel
 open SpectreCoff.Layout
+open SpectreCoff.Output
 
 type PanelSettings()  =
     inherit CommandSettings()
@@ -12,11 +13,18 @@ type PanelExample() =
     interface ICommandLimiter<PanelSettings>
 
     override _.Execute(_context, _) = 
-        let examplePanel = panel "First !" "Important text can be highlighted by surrounding it with a border and title." 
-        examplePanel |> toConsole    
+        let principles =  BI [
+            C "Composability over Inheritance" 
+            P "Make illegal states irrepresentable"
+            P "Types are your friend"
+            C "Immutability over, well, mutability"
+            C "Declarative over Imperative"
+        ]
+        panel (P " Guiding principles ") (principles) 
+        |> toConsole    
 
-        let custom = customPanel { defaultPanelLayout with Sizing = Expand } "Custom !!" "That surrounding border can be customized easily, e.g., to take up as much horizontal space as needed." 
-        custom |> toConsole
+        customPanel { defaultPanelLayout with Sizing = Expand } (E "Custom !!") (P "That surrounding border can be customized easily, e.g., to take up as much horizontal space as needed.") 
+        |> toConsole
         0
 
 open SpectreCoff.Cli

--- a/src/spectrecoff-cli/commands/Panel.fs
+++ b/src/spectrecoff-cli/commands/Panel.fs
@@ -13,17 +13,24 @@ type PanelExample() =
     interface ICommandLimiter<PanelSettings>
 
     override _.Execute(_context, _) = 
-        let principles =  BI [
-            C "Composability over Inheritance" 
-            P "Make illegal states irrepresentable"
-            P "Types are your friend"
-            C "Immutability over, well, mutability"
-            C "Declarative over Imperative"
-        ]
-        panel (P " Guiding principles ") (principles) 
+        let principles =  
+            BI [
+                C "Composability over inheritance" 
+                P "Make illegal states irrepresentable"
+                P "Types are your friend"
+                C "Immutability over, well, mutability"
+                C "Declarative over imperative"
+            ]
+        let header = 
+            P "Guiding principles "
+            |> toMarkedUpString
+
+        principles 
+        |> panel header 
         |> toConsole    
 
-        customPanel { defaultPanelLayout with Sizing = Expand } (E "Custom !!") (P "That surrounding border can be customized easily, e.g., to take up as much horizontal space as needed.") 
+        (P "That surrounding border can be customized easily, e.g., to take up as much horizontal space as needed.") 
+        |> customPanel { defaultPanelLayout with Sizing = Expand } " Customization " 
         |> toConsole
         0
 

--- a/src/spectrecoff-cli/commands/Progress.fs
+++ b/src/spectrecoff-cli/commands/Progress.fs
@@ -2,7 +2,7 @@
 
 open Spectre.Console
 open Spectre.Console.Cli
-open SpectreCoff
+
 open SpectreCoff.BarChart
 open SpectreCoff.Layout
 open SpectreCoff.Output
@@ -42,5 +42,5 @@ type Progress() =
 
         items
         |> barChart "SpectreCoff Module Progress"
-        |> BarChart.toConsole
+        |> toConsole
         0

--- a/src/spectrecoff-cli/commands/Prompt.fs
+++ b/src/spectrecoff-cli/commands/Prompt.fs
@@ -35,7 +35,7 @@ type PromptDocumentation() =
         NewLine |> toConsole
         pumped "Prompt module"
         |> alignedRule Left 
-        |> SpectreCoff.Rule.toConsole
+        |> toConsole
         
         Many [
             CO [

--- a/src/spectrecoff-cli/commands/Rule.fs
+++ b/src/spectrecoff-cli/commands/Rule.fs
@@ -15,17 +15,17 @@ type RuleExample() =
     override _.Execute(_context, _settings) =
         pumped "Hello"
         |> alignedRule Left   
-        |> SpectreCoff.Rule.toConsole
+        |> toConsole
 
         "Fellow" 
         |> rule
-        |> SpectreCoff.Rule.toConsole
+        |> toConsole
          
         edgy "Developer"
         |> alignedRule Right 
-        |> SpectreCoff.Rule.toConsole
+        |> toConsole
 
-        emptyRule |> SpectreCoff.Rule.toConsole
+        emptyRule |> toConsole
         0
 
 open SpectreCoff.Cli
@@ -40,7 +40,7 @@ type RuleDocumentation() =
         NewLine |> toConsole
         pumped "Rule module"
         |> alignedRule Left 
-        |> SpectreCoff.Rule.toConsole
+        |> toConsole
         
         Many [
             CO [
@@ -58,7 +58,7 @@ type RuleDocumentation() =
             NL
             C "Other rules can be used without changing the default by passing in the alignment as an argument to: "
             BI [ 
-                P "alignedRule: Alignment -> string -> Rule"
+                P "alignedRule: Alignment -> string -> Renderable"
             ]
             NL
             CO [C "The rule can be printed to the console with the"; P "toConsole"; C "function."]

--- a/src/spectrecoff/BarChart.fs
+++ b/src/spectrecoff/BarChart.fs
@@ -2,9 +2,10 @@
 
 open Spectre.Console
 open SpectreCoff.Layout
+open SpectreCoff.Output
 
 let mutable width = 60
-let mutable alignment = Alignment.Center
+let mutable alignment = Center
 
 let mutable colors = [
     Color.Blue
@@ -19,11 +20,10 @@ type ChartItem =
     | ChartItem of string * float
     | ChartItemWithColor of string * float * Color
 
-let createBasicChart label =
+let private createBasicChart label =
     let chart = BarChart()
     chart.Width <- width
     chart.Label <- label
-
     chart.LabelAlignment <-
         match alignment with
         | Left -> Justify.Left
@@ -43,6 +43,5 @@ let barChart label (items: ChartItem list) =
     |> List.iter (fun item -> chart.AddItem(item) |> ignore)
 
     chart
-
-let toConsole (barChart: BarChart) =
-    barChart |> AnsiConsole.Write
+    :> Rendering.IRenderable
+    |> Renderable

--- a/src/spectrecoff/Figlet.fs
+++ b/src/spectrecoff/Figlet.fs
@@ -17,9 +17,8 @@ let customFiglet (alignment: Alignment) (color: Color) content =
     | Right -> figlet.RightAligned() |> ignore
 
     figlet
+    :> Rendering.IRenderable
+    |> Renderable
 
 let figlet = 
     customFiglet defaultAlignment defaultColor 
-
-let toConsole (figlet: FigletText) = 
-    figlet |> AnsiConsole.Write

--- a/src/spectrecoff/Output.fs
+++ b/src/spectrecoff/Output.fs
@@ -127,15 +127,16 @@ let rec toMarkedUpString (payload: OutputPayload) =
 
 let rec payloadToRenderable (payload: OutputPayload) =
     match payload with
-    | Renderable renderable -> renderable
+    | Renderable renderable -> [ renderable ]
+    | Many payloads -> payloads |> List.collect payloadToRenderable
     | _ -> 
-        payload    
-        |> toMarkedUpString 
-        |> appendNewline
-        |> Markup 
-        :> Rendering.IRenderable
+        [ payload    
+          |> toMarkedUpString 
+          |> appendNewline
+          |> Markup 
+          :> Rendering.IRenderable ]
 
 let toConsole (payload: OutputPayload) =
     payload
     |> payloadToRenderable
-    |> AnsiConsole.Write
+    |> List.iter AnsiConsole.Write

--- a/src/spectrecoff/Panel.fs
+++ b/src/spectrecoff/Panel.fs
@@ -14,9 +14,9 @@ let defaultPanelLayout: PanelLayout =
        Sizing = Collapse
        Padding = AllEqual 2 }
 
-let customPanel (layout: PanelLayout) (header: OutputPayload) (content: OutputPayload) =
+let customPanel (layout: PanelLayout) (header: string) (content: OutputPayload) =
     let panel = Panel(content |> toMarkedUpString)
-    panel.Header <- PanelHeader(header |> toMarkedUpString)
+    panel.Header <- PanelHeader(header)
 
     match layout.Sizing with
     | Expand -> panel.Expand <- true

--- a/src/spectrecoff/Panel.fs
+++ b/src/spectrecoff/Panel.fs
@@ -2,6 +2,7 @@ module SpectreCoff.Panel
 
 open Spectre.Console
 open SpectreCoff.Layout
+open SpectreCoff.Output
 
 type PanelLayout =
     {  Border: BoxBorder;
@@ -13,9 +14,9 @@ let defaultPanelLayout: PanelLayout =
        Sizing = Collapse
        Padding = AllEqual 2 }
 
-let customPanel (layout: PanelLayout) (header: string) (content: string) =
-    let panel = Panel(content)
-    panel.Header <- PanelHeader(header)
+let customPanel (layout: PanelLayout) (header: OutputPayload) (content: OutputPayload) =
+    let panel = Panel(content |> toMarkedUpString)
+    panel.Header <- PanelHeader(header |> toMarkedUpString)
 
     match layout.Sizing with
     | Expand -> panel.Expand <- true
@@ -27,9 +28,8 @@ let customPanel (layout: PanelLayout) (header: string) (content: string) =
     | TopRightBottomLeft (l,t,r,b) -> panel.Padding <- Spectre.Console.Padding(l, t, r, b)
 
     panel
+    :> Rendering.IRenderable
+    |> Renderable
 
 let panel =
    customPanel defaultPanelLayout
-
-let toConsole (panel: Panel) =
-    panel |> AnsiConsole.Write

--- a/src/spectrecoff/Rule.fs
+++ b/src/spectrecoff/Rule.fs
@@ -1,20 +1,27 @@
 ﻿module SpectreCoff.Rule
 open SpectreCoff.Layout
+open SpectreCoff.Output
+
 open Spectre.Console
 
 let mutable defaultAlignment = Center
 
 let emptyRule =
     Rule()
+    :> Rendering.IRenderable
+    |> Renderable
 
 let alignedRule alignment content =
-    match alignment with
-    | Left -> Rule(content).LeftAligned()
-    | Center -> Rule(content)
-    | Right -> Rule(content).RightAligned()
+    let rule = 
+        match alignment with
+        | Left -> Rule(content).LeftAligned()
+        | Center -> Rule(content)
+        | Right -> Rule(content).RightAligned()
+
+    rule
+    :> Rendering.IRenderable
+    |> Renderable
 
 let rule =
     alignedRule defaultAlignment
-
-let toConsole (rule: Rule) =
-    rule |> AnsiConsole.Write
+    

--- a/src/spectrecoff/Table.fs
+++ b/src/spectrecoff/Table.fs
@@ -103,6 +103,5 @@ let customTable (layout: TableLayout) (headers: Header list) (rows: Row list) =
 let table =
     customTable defaultTableLayout
 
-// Output methods
 let toConsole (table: Table) = 
     table |> AnsiConsole.Write

--- a/src/spectrecoff/Table.fs
+++ b/src/spectrecoff/Table.fs
@@ -59,7 +59,7 @@ let private toSpectreContentColumn (content: HeaderContent) =
     match content with
     | Simple value -> TableColumn(value) 
     | Renderable renderable -> TableColumn(renderable) 
-    | Payload renderable -> TableColumn(renderable |> payloadToRenderable)
+    | Payload renderable -> TableColumn((renderable |> payloadToRenderable).Head)
 
 let private toSpectreColumn (header: Header) =
     match header with
@@ -72,7 +72,7 @@ let addRow (table: Table) (row: Row) =
         | Renderables renderables -> renderables
         | Strings values -> values |> List.map (fun value -> Text value)
         | Numbers values -> values |> List.map (fun value -> Text (value.ToString()))
-        | Payloads payloads -> payloads |> List.map (fun payload -> payloadToRenderable payload)
+        | Payloads payloads -> payloads |> List.map (fun payload -> (payloadToRenderable payload).Head)
 
     table.AddRow(values) |> ignore
 


### PR DESCRIPTION
So, I started removing toConsole from the first modules. I also extended the panel to now accept renderable title and content (before it only worked with unstyled strings).