### PR TITLE
Panel can't handle renderable

### DIFF
--- a/src/spectrecoff-cli/commands/Panel.fs
+++ b/src/spectrecoff-cli/commands/Panel.fs
@@ -21,15 +21,14 @@ type PanelExample() =
             ]
             
         let header = 
-            P "Guiding principles "
+            P " Guiding principles "
             |> toMarkedUpString
 
         principles
-        |> toMarkedUpString 
         |> panel header 
         |> toConsole    
 
-        pumped "That surrounding border can be customized easily, e.g., to take up as much horizontal space as needed."
+        P "That surrounding border can be customized easily, e.g., to take up as much horizontal space as needed."
         |> customPanel { defaultPanelLayout with Sizing = Expand } " Customization " 
         |> toConsole
         0

--- a/src/spectrecoff-cli/commands/Panel.fs
+++ b/src/spectrecoff-cli/commands/Panel.fs
@@ -19,15 +19,17 @@ type PanelExample() =
                 C "Immutability over, well, mutability"
                 C "Declarative over imperative"
             ]
+            
         let header = 
             P "Guiding principles "
             |> toMarkedUpString
 
-        principles 
+        principles
+        |> toMarkedUpString 
         |> panel header 
         |> toConsole    
 
-        (P "That surrounding border can be customized easily, e.g., to take up as much horizontal space as needed.") 
+        pumped "That surrounding border can be customized easily, e.g., to take up as much horizontal space as needed."
         |> customPanel { defaultPanelLayout with Sizing = Expand } " Customization " 
         |> toConsole
         0

--- a/src/spectrecoff/Panel.fs
+++ b/src/spectrecoff/Panel.fs
@@ -15,9 +15,13 @@ let defaultPanelLayout: PanelLayout =
        Sizing = Collapse
        Padding = AllEqual 2 }
 
-let customPanel (layout: PanelLayout) (header: string) (content: string) =
-    let panel = Panel(content)
-    panel.Header <- PanelHeader(header)
+let customPanel (layout: PanelLayout) header (content: OutputPayload) =
+    let panel = 
+        match content with
+        | Renderable renderable -> Panel renderable
+        | _ -> Panel (toMarkedUpString content)
+        
+    panel.Header <- PanelHeader header
 
     match layout.Sizing with
     | Expand -> panel.Expand <- true

--- a/src/spectrecoff/Panel.fs
+++ b/src/spectrecoff/Panel.fs
@@ -15,8 +15,8 @@ let defaultPanelLayout: PanelLayout =
        Sizing = Collapse
        Padding = AllEqual 2 }
 
-let customPanel (layout: PanelLayout) (header: string) (content: OutputPayload) =
-    let panel = Panel(content |> toMarkedUpString)
+let customPanel (layout: PanelLayout) (header: string) (content: string) =
+    let panel = Panel(content)
     panel.Header <- PanelHeader(header)
 
     match layout.Sizing with


### PR DESCRIPTION
Previously, content was of type `OutputPayload`. As the Spectre class, however, expects a string, this was mapped using `toMarkedUpString` - which fails on the Renderable branch. Now the signature is truer, as the panel content is string, and it is the responsibility of the caller to 'use a valid marked up string'.