### PR TITLE
Auto-opening modules

### DIFF
--- a/src/spectrecoff-cli/commands/BarChart.fs
+++ b/src/spectrecoff-cli/commands/BarChart.fs
@@ -2,11 +2,7 @@
 
 open Spectre.Console
 open Spectre.Console.Cli
-open SpectreCoff.Chart
-open SpectreCoff.Chart.BarChart
-open SpectreCoff.Cli
-open SpectreCoff.Layout
-open SpectreCoff.Output
+open SpectreCoff
 
 type BarChartSettings() =
     inherit CommandSettings()
@@ -38,5 +34,5 @@ type BarChartDocumentation() =
     interface ICommandLimiter<BarChartSettings>
 
     override _.Execute(_context, _settings) =
-        Theme.setDocumentationStyle
+        Cli.Theme.setDocumentationStyle
         0

--- a/src/spectrecoff-cli/commands/Figlet.fs
+++ b/src/spectrecoff-cli/commands/Figlet.fs
@@ -1,11 +1,8 @@
 namespace SpectreCoff.Cli.Commands
 
-open Spectre.Console.Cli
 open Spectre.Console
-
-open SpectreCoff.Layout
-open SpectreCoff.Figlet
-open SpectreCoff.Output
+open Spectre.Console.Cli
+open SpectreCoff
 
 type FigletSettings()  =
     inherit CommandSettings()
@@ -24,15 +21,12 @@ type FigletExample() =
         |> toConsole
         0
 
-open SpectreCoff.Cli
-open SpectreCoff.Rule
-
 type FigletDocumentation() =
     inherit Command<FigletSettings>()
     interface ICommandLimiter<FigletSettings>
 
     override _.Execute(_context, _settings) =
-        Theme.setDocumentationStyle
+        Cli.Theme.setDocumentationStyle
 
         NewLine |> toConsole
         pumped "Figlet module"

--- a/src/spectrecoff-cli/commands/Output.fs
+++ b/src/spectrecoff-cli/commands/Output.fs
@@ -2,8 +2,7 @@ namespace SpectreCoff.Cli.Commands
 
 open Spectre.Console
 open Spectre.Console.Cli
-open SpectreCoff.Layout
-open SpectreCoff.Output
+open SpectreCoff
 
 type OutputSettings() =
     inherit CommandSettings()
@@ -81,7 +80,7 @@ type OutputExample() =
                 P "several"
                 E "items"
             ]
-            SpectreCoff.Rule.rule "Links and Emojis"
+            rule "Links and Emojis"
             CO [
                 C "You can easily render clickable links:"
                 Link "https://www.spectreconsole.net/markup"
@@ -100,13 +99,12 @@ type OutputExample() =
         ] |> toConsole
         0
 
-open SpectreCoff.Cli
 
 type OutputDocumentation() =
     inherit Command<OutputSettings>()
     interface ICommandLimiter<OutputSettings>
 
     override _.Execute(_context, _) =
-        Theme.setDocumentationStyle
+        Cli.Theme.setDocumentationStyle
         Edgy "Sorry, this documentation is not available yet." |> toConsole
         0

--- a/src/spectrecoff-cli/commands/Panel.fs
+++ b/src/spectrecoff-cli/commands/Panel.fs
@@ -1,9 +1,7 @@
 namespace SpectreCoff.Cli.Commands
 
 open Spectre.Console.Cli
-open SpectreCoff.Panel
-open SpectreCoff.Layout
-open SpectreCoff.Output
+open SpectreCoff
 
 type PanelSettings()  =
     inherit CommandSettings()
@@ -34,12 +32,10 @@ type PanelExample() =
         |> toConsole
         0
 
-open SpectreCoff.Cli
-
 type PanelDocumentation() =
     inherit Command<PanelSettings>()
     interface ICommandLimiter<PanelSettings>
     
     override _.Execute(_context, _) = 
-        Theme.setDocumentationStyle
+        Cli.Theme.setDocumentationStyle
         0

--- a/src/spectrecoff-cli/commands/Progress.fs
+++ b/src/spectrecoff-cli/commands/Progress.fs
@@ -2,11 +2,7 @@
 
 open Spectre.Console
 open Spectre.Console.Cli
-
-open SpectreCoff.Chart
-open SpectreCoff.Layout
-open SpectreCoff.Chart.BarChart
-open SpectreCoff.Output
+open SpectreCoff
 
 type ProgressSettings() =
     inherit CommandSettings()

--- a/src/spectrecoff-cli/commands/Prompt.fs
+++ b/src/spectrecoff-cli/commands/Prompt.fs
@@ -1,9 +1,7 @@
 namespace SpectreCoff.Cli.Commands
 
 open Spectre.Console.Cli
-open SpectreCoff.Prompt
-open SpectreCoff.Rule
-open SpectreCoff.Output
+open SpectreCoff
 
 type PromptSettings()  =
     inherit CommandSettings()
@@ -22,15 +20,12 @@ type PromptExample() =
         | false -> printMarkedUpInline (edgy "Ok, maybe later :/")
         0
 
-open SpectreCoff.Layout
-open SpectreCoff.Cli
-
 type PromptDocumentation() =
     inherit Command<PromptSettings>()
     interface ICommandLimiter<PromptSettings>
     
     override _.Execute(_context, _) = 
-        Theme.setDocumentationStyle
+        Cli.Theme.setDocumentationStyle
         
         NewLine |> toConsole
         pumped "Prompt module"

--- a/src/spectrecoff-cli/commands/Rule.fs
+++ b/src/spectrecoff-cli/commands/Rule.fs
@@ -1,9 +1,7 @@
 ﻿namespace SpectreCoff.Cli.Commands
 
 open Spectre.Console.Cli
-open SpectreCoff.Layout
-open SpectreCoff.Rule
-open SpectreCoff.Output
+open SpectreCoff
 
 type RuleSettings()  =
     inherit CommandSettings()
@@ -28,14 +26,12 @@ type RuleExample() =
         emptyRule |> toConsole
         0
 
-open SpectreCoff.Cli
-
 type RuleDocumentation() =
     inherit Command<RuleSettings>()
     interface ICommandLimiter<RuleSettings>
 
     override _.Execute(_context, _settings) =
-        Theme.setDocumentationStyle
+        Cli.Theme.setDocumentationStyle
         
         NewLine |> toConsole
         pumped "Rule module"

--- a/src/spectrecoff-cli/commands/Table.fs
+++ b/src/spectrecoff-cli/commands/Table.fs
@@ -1,10 +1,8 @@
 namespace SpectreCoff.Cli.Commands
 
-open Spectre.Console.Cli
-open SpectreCoff.Table
-open SpectreCoff.Output
-open SpectreCoff.Layout
 open Spectre.Console
+open Spectre.Console.Cli
+open SpectreCoff
 
 type TableSettings()  =
     inherit CommandSettings()
@@ -27,12 +25,12 @@ type TableExample() =
 
         P "This shows a table with a default and custom laid-out column." |> toConsole
         let exampleTable = table headers rows
-        exampleTable |> SpectreCoff.Table.toConsole
+        exampleTable |> Table.toConsole
         
         NewLine |> toConsole
         P "Rows can be added to the same table later on." |> toConsole
         addRow exampleTable (Numbers [23; 45])
-        exampleTable |> SpectreCoff.Table.toConsole
+        exampleTable |> Table.toConsole
 
         NewLine |> toConsole
         P "Tables can be nested, or contain other markup" |> toConsole
@@ -45,23 +43,21 @@ type TableExample() =
         [ Renderables [ exampleTable;  exampleMarkup ]
           Payloads [ P "Let's"; E "Go!" ] ] 
             |> table headers 
-            |> SpectreCoff.Table.toConsole
+            |> Table.toConsole
 
         NewLine |> toConsole
         P "The table can be customized, too." |> toConsole
         customTable  
             { defaultTableLayout with Sizing = Collapse; Border = TableBorder.Minimal } headers rows 
-            |> SpectreCoff.Table.toConsole
+            |> Table.toConsole
         
         0
-
-open SpectreCoff.Cli
 
 type TableDocumentation() =
     inherit Command<TableSettings>()
     interface ICommandLimiter<TableSettings>
 
     override _.Execute(_context, _) =
-        Theme.setDocumentationStyle
+        Cli.Theme.setDocumentationStyle
         Edgy "Sorry, this documentation is not available yet." |> toConsole    
         0

--- a/src/spectrecoff/Chart.fs
+++ b/src/spectrecoff/Chart.fs
@@ -1,4 +1,5 @@
-﻿module SpectreCoff.Chart
+﻿[<AutoOpen>]
+module SpectreCoff.Chart
 open Spectre.Console
 open SpectreCoff.Layout
 open SpectreCoff.Output
@@ -16,6 +17,7 @@ type ChartItem =
     | ChartItem of string * float
     | ChartItemWithColor of string * float * Color
 
+[<AutoOpen>]
 module BarChart =
     let mutable width = 60
     let mutable alignment = Center
@@ -45,6 +47,7 @@ module BarChart =
         :> Rendering.IRenderable
         |> Renderable
 
+[<AutoOpen>]
 module BreakdownChart =
     let mutable width = 60
 

--- a/src/spectrecoff/Figlet.fs
+++ b/src/spectrecoff/Figlet.fs
@@ -1,3 +1,4 @@
+[<AutoOpen>]
 module SpectreCoff.Figlet
 
 open Spectre.Console 

--- a/src/spectrecoff/Layout.fs
+++ b/src/spectrecoff/Layout.fs
@@ -1,3 +1,4 @@
+[<AutoOpen>]
 module SpectreCoff.Layout
 
 type Alignment =

--- a/src/spectrecoff/Output.fs
+++ b/src/spectrecoff/Output.fs
@@ -1,3 +1,4 @@
+[<AutoOpen>]
 module SpectreCoff.Output
 
 open SpectreCoff.Layout

--- a/src/spectrecoff/Panel.fs
+++ b/src/spectrecoff/Panel.fs
@@ -1,3 +1,4 @@
+[<AutoOpen>]
 module SpectreCoff.Panel
 
 open Spectre.Console

--- a/src/spectrecoff/Prompt.fs
+++ b/src/spectrecoff/Prompt.fs
@@ -1,4 +1,6 @@
+[<AutoOpen>]
 module SpectreCoff.Prompt
+
 open Spectre.Console 
 
 let selectionPrompt question choices = 

--- a/src/spectrecoff/Rule.fs
+++ b/src/spectrecoff/Rule.fs
@@ -1,4 +1,5 @@
-﻿module SpectreCoff.Rule
+﻿[<AutoOpen>]
+module SpectreCoff.Rule
 open SpectreCoff.Layout
 open SpectreCoff.Output
 

--- a/src/spectrecoff/Table.fs
+++ b/src/spectrecoff/Table.fs
@@ -1,3 +1,4 @@
+[<AutoOpen>]
 module SpectreCoff.Table
 
 open Spectre.Console


### PR DESCRIPTION
Before this PR, all modules that were used in a file needed to be opened separately. Contrast that to how Spectre works - there is basically only one namespace one has to open: `Spectre.Console`.

I think it would be a good idea to mimic this behaviour. With the AutoOpen attribute on the submodules of SpectreCoff, they will be opened as soon as the parent is. So all a consumer has to do is `open SpectreCoff`. 

But internally, we still benefit from the modules as a way to organize and reference code ;)