### PR TITLE
Tree module returns OutputPayload

### DIFF
--- a/src/spectrecoff-cli/commands/Tree.fs
+++ b/src/spectrecoff-cli/commands/Tree.fs
@@ -26,7 +26,6 @@ type TreeExample() =
                 | _ -> node)
         
         tree (P "FizzBuzz-Tree!") nodes 
-        |> toOutputPayload 
         |> toConsole
 
         customTree 
@@ -36,7 +35,6 @@ type TreeExample() =
                 Decoration = Some Decoration.Bold } 
             (P "Custom-Tree!") 
             [ for i in 1 .. 3 -> node (C $"Node {i}!") [] ] 
-        |> toOutputPayload 
         |> toConsole
         0
 

--- a/src/spectrecoff/Tree.fs
+++ b/src/spectrecoff/Tree.fs
@@ -69,9 +69,8 @@ let customTree (layout: TreeLayout) (rootContent: OutputPayload ) (nodes: TreeNo
     |> Tree 
     |> applyLayout layout
     |> attachToRoot nodes
+    :> Rendering.IRenderable
+    |> Renderable
 
-let tree: OutputPayload -> TreeNode list -> Tree =
+let tree =
     customTree defaultTreeLayout
-
-type Tree with 
-    member self.toOutputPayload = toOutputPayload self 


### PR DESCRIPTION
Changed the tree function so it returns an OutputPayload (like Figlet, Rule, etc). 

I was just confused from the table, where we actually return the Table (and additionally provide the extension toOutputPayload), since the Table instance is useful to the caller, e.g., for adding rows to an existing table.

So in short: 

- Immutable things -> module function returns thing wrapped in OutputPayload
- Mutable thing (e.g. table) -> mudule returns the Spectre instance, and fucntions to map it to an OutputPayload.


 