### PR TITLE
Feature/style and color cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,15 +78,15 @@ The following table lists all payloads currently available:
 
 | Type         | Alias | Description                                | Parameters                                    | Configurbility |
 | ------------ | ----- | ------------------------------------------ | --------------------------------------------- | -------------- |
-| MarkupS      | MS    | Content marked up with a style             | style: `SpectreCoff.Layout.Style`<br /> content: `string`                              | -              |
-| MarkupC      | MC    | Content marked up with a style             | color: `Spectre.Console.Color`<br /> content: `string`                             | -              |
-| MarkupCS     | MCS   | Content marked up with a color and a style | style: `SpectreCoff.Layout.Style`<br /> color: `Spectre.Console.Color`<br /> content: `string` | - |
-| Calm     | C     | Convenience style for calm output      | content: `string`                                      | color: `Output.calmColor` <br /> style: `Output.calmStyle` |
-| Pumped    | P     | Convenience style pumped output             | content: `string`                                | color: `Output.pumpedColor` <br /> style: `Output.pumpedStyle` |
-| Edgy         | E     | Convenience style for edgy output             | content: `string`                             | color: `Output.edgyingColor` <br /> style: `Output.edgyingStyle` |
+| MarkupD      | MD    | Content marked up with decorations             | decorations: `Spectre.Console.Decoration list`<br /> content: `string`                              | -              |
+| MarkupC      | MC    | Content marked up with a color             | color: `Spectre.Console.Color`<br /> content: `string`                             | -              |
+| MarkupCD     | MCD   | Content marked up with a color and decorations | decorations: `Spectre.Console.Decoration list`<br /> color: `Spectre.Console.Color`<br /> content: `string` | - |
+| Calm     | C     | Convenience style for calm output      | content: `string`                                      | color: `Output.calmLook.Color` <br /> decorations: `Output.calmLook.Decorations` |
+| Pumped    | P     | Convenience style pumped output             | content: `string`                                | color: `Output.pumpedLook.Color` <br /> decorations: `Output.pumpedLook.Decorations` |
+| Edgy         | E     | Convenience style for edgy output             | content: `string`                             | color: `Output.edgyLook.Color` <br /> decorations: `Output.edgyLook.Decorations` |
 | Vanilla       | V     | Raw type, no processing will be done       | content: `string`                             | - 
-| Link         | -     | Clickable link showing the URL             | content: `string`                             | - 
-| LinkWithLabel| -     | Clickable link showing a label             | label: `string` <br /> link: `string`         | - 
+| Link         | -     | Clickable link showing the URL             | content: `string`                             | color: `Output.linkLook.Color` <br /> decorations: `Output.linkLook.Decorations` 
+| LinkWithLabel| -     | Clickable link showing a label             | label: `string` <br /> link: `string`         | color: `Output.linkLook.Color` <br /> decorations: `Output.linkLook.Decorations` 
 | Collection   | CO    | Aggregate multiple payloads in one line    | items: list of `OutputPayload`. <br /> Not allowed: `Renderable`, `BulletItems` | - 
 | Emoji        | -     | An emoji, given by it's string literal | emoji: `string` | -
 | BulletItems  | BI    | Show list of items with bullet points      | items: list of `OutputPayload`. <br /> Not allowed: `Renderable`, `BulletItems` | bullet item prefix: `Output.bulletItemPrefix`
@@ -101,8 +101,7 @@ Pumped "Hello world" |> toConsole
 ```
 The convenience styles can be altered by mutating the corresponding variables, e.g.,
 ```Fs
-pumpedColor <- Color.Yellow
-pumpedStyle <- Style.Italic
+pumpedLook <- { Color = Color.Yellow; Decorations = [ Decoration.Italic ] }
 ```
 
 #### Composition of Payloads

--- a/src/spectrecoff-cli/commands/Calendar.fs
+++ b/src/spectrecoff-cli/commands/Calendar.fs
@@ -33,8 +33,14 @@ type CalendarExample() =
         let settings =
           { defaultCalendarSettings with
               Culture = Some (Culture "de-DE")
-              HeaderLook = { Color = edgyLook.Color; Decorations = [ Decoration.Italic ] }
-              HighlightLook = { Color = Color.Aquamarine1; Decorations = [ Decoration.Invert ] } }
+              HeaderLook = 
+                { Color = edgyLook.Color
+                  BackgroundColor = Some Color.Purple
+                  Decorations = [ Decoration.Italic ] }
+              HighlightLook = 
+                { Color = Color.Yellow
+                  BackgroundColor = Some Color.Purple
+                  Decorations = [ Decoration.Invert ] } }
 
         customCalendar settings (Year 2025) (Month 2)
         |> addEvent (Event (Year 2025, Month 2, Day 22))

--- a/src/spectrecoff-cli/commands/Calendar.fs
+++ b/src/spectrecoff-cli/commands/Calendar.fs
@@ -33,8 +33,8 @@ type CalendarExample() =
         let settings =
           { defaultCalendarSettings with
               Culture = Some (Culture "de-DE")
-              HeaderLook = { Color = edgyLook.Color; Decoration = [ Decoration.Italic ] }
-              HighlightLook = { Color = Color.Aquamarine1; Decoration = [ Decoration.Invert ] } }
+              HeaderLook = { Color = edgyLook.Color; Decorations = [ Decoration.Italic ] }
+              HighlightLook = { Color = Color.Aquamarine1; Decorations = [ Decoration.Invert ] } }
 
         customCalendar settings (Year 2025) (Month 2)
         |> addEvent (Event (Year 2025, Month 2, Day 22))

--- a/src/spectrecoff-cli/commands/Calendar.fs
+++ b/src/spectrecoff-cli/commands/Calendar.fs
@@ -32,9 +32,9 @@ type CalendarExample() =
         // You can use custom settings to control how the calendar is displayed
         let settings =
           { defaultCalendarSettings with
-                Culture = Some (Culture "de-DE")
-                HeaderLook = { Color = edgyLook.Color; Decoration = Decoration.Italic }
-                HighlightLook = { Color = Color.Aquamarine1; Decoration = Decoration.Invert } }
+              Culture = Some (Culture "de-DE")
+              HeaderLook = { Color = edgyLook.Color; Decoration = [ Decoration.Italic ] }
+              HighlightLook = { Color = Color.Aquamarine1; Decoration = [ Decoration.Invert ] } }
 
         customCalendar settings (Year 2025) (Month 2)
         |> addEvent (Event (Year 2025, Month 2, Day 22))

--- a/src/spectrecoff-cli/commands/Calendar.fs
+++ b/src/spectrecoff-cli/commands/Calendar.fs
@@ -33,10 +33,8 @@ type CalendarExample() =
         let settings =
           { defaultCalendarSettings with
                 Culture = Some (Culture "de-DE")
-                HeaderColor = edgyColor
-                HeaderStyle = Decoration.Italic
-                HighlightColor = Some Color.Aquamarine1
-                HighlightStyle = Some Decoration.Invert }
+                HeaderLook = { Color = edgyLook.Color; Decoration = Decoration.Italic }
+                HighlightLook = { Color = Color.Aquamarine1; Decoration = Decoration.Invert } }
 
         customCalendar settings (Year 2025) (Month 2)
         |> addEvent (Event (Year 2025, Month 2, Day 22))

--- a/src/spectrecoff-cli/commands/Output.fs
+++ b/src/spectrecoff-cli/commands/Output.fs
@@ -21,8 +21,8 @@ type OutputExample() =
 
         // There are several ways to print a single line.
         // The generic way
-        MCS (Color.Red, Decoration.Underline, "This is underline red") |> toConsole
-        MS (Decoration.Underline, "This is underline.") |> toConsole
+        MCS (Color.Red, [ Decoration.Underline ], "This is underline red") |> toConsole
+        MS ([ Decoration.Underline; Decoration.Dim ], "This is underline.") |> toConsole
         MC (Color.Red, "This is red") |> toConsole
         NewLine |> toConsole
 
@@ -43,7 +43,7 @@ type OutputExample() =
         Vanilla "This let's you pass in a style as defined by Spectre." |> toConsole
         V "V is a short for Vanilla." |> toConsole
         V "In order to be able to write the styles easily, there are some functions:" |> toConsole
-        V $"""You can use {markupString (Some Color.Purple) (Some Decoration.Bold) "the markup"} function,""" |> toConsole
+        V $"""You can use {markupString (Some Color.Purple) [ Decoration.Bold ] "the markup"} function,""" |> toConsole
         V $"""or {calm "the calm"}, {pumped "the pumped"} {edgy "or the edgy"} functions""" |> toConsole
         V "to utilize the same styles as defined in the current theme." |> toConsole
         V $"""As you can see, {pumped "Vanilla"} is especially useful for styles in {edgy "one line!"} (more on that below).""" |> toConsole

--- a/src/spectrecoff-cli/commands/Output.fs
+++ b/src/spectrecoff-cli/commands/Output.fs
@@ -13,16 +13,16 @@ type OutputExample() =
 
     override _.Execute(_context, _) =
 
-        pumpedColor <- Color.Fuchsia
-        edgyColor <- Color.BlueViolet
-        calmColor <- Color.Green
+        pumpedLook <- { pumpedLook with Color = Color.Fuchsia }
+        edgyLook <- { edgyLook with Color = Color.BlueViolet }
+        calmLook <- { calmLook with Color = Color.Green }
 
         NewLine |> toConsole
 
         // There are several ways to print a single line.
         // The generic way
-        MCS (Color.Red, Underline, "This is underline red") |> toConsole
-        MS (Underline, "This is underline.") |> toConsole
+        MCS (Color.Red, Decoration.Underline, "This is underline red") |> toConsole
+        MS (Decoration.Underline, "This is underline.") |> toConsole
         MC (Color.Red, "This is red") |> toConsole
         NewLine |> toConsole
 
@@ -43,7 +43,7 @@ type OutputExample() =
         Vanilla "This let's you pass in a style as defined by Spectre." |> toConsole
         V "V is a short for Vanilla." |> toConsole
         V "In order to be able to write the styles easily, there are some functions:" |> toConsole
-        V $"""You can use {markupString (Some Color.Purple) (Some Bold) "the markup"} function,""" |> toConsole
+        V $"""You can use {markupString (Some Color.Purple) (Some Decoration.Bold) "the markup"} function,""" |> toConsole
         V $"""or {calm "the calm"}, {pumped "the pumped"} {edgy "or the edgy"} functions""" |> toConsole
         V "to utilize the same styles as defined in the current theme." |> toConsole
         V $"""As you can see, {pumped "Vanilla"} is especially useful for styles in {edgy "one line!"} (more on that below).""" |> toConsole

--- a/src/spectrecoff-cli/commands/Output.fs
+++ b/src/spectrecoff-cli/commands/Output.fs
@@ -21,8 +21,8 @@ type OutputExample() =
 
         // There are several ways to print a single line.
         // The generic way
-        MCS (Color.Red, [ Decoration.Underline ], "This is underline red") |> toConsole
-        MS ([ Decoration.Underline; Decoration.Dim ], "This is underline.") |> toConsole
+        MCD (Color.Red, [ Decoration.Underline ], "This is underline red") |> toConsole
+        MD ([ Decoration.Underline; Decoration.Dim ], "This is underline.") |> toConsole
         MC (Color.Red, "This is red") |> toConsole
         NewLine |> toConsole
 

--- a/src/spectrecoff-cli/commands/Table.fs
+++ b/src/spectrecoff-cli/commands/Table.fs
@@ -1,5 +1,6 @@
 namespace SpectreCoff.Cli.Commands
 
+open Spectre.Console;
 open Spectre.Console.Cli
 open SpectreCoff
 
@@ -40,12 +41,12 @@ type TableExample() =
             |> withFooter (Pumped "Footer works, too!") 
             |> withLayout { defaultColumnLayout with Alignment = Right }
         ]
-        [ Payloads [ exampleTable.toOutputPayload;  MCS (Spectre.Console.Color.Red, Bold, "The bigger the exponent, the faster the sequence grows.") ]
+        [ Payloads [ exampleTable.toOutputPayload;  MCS (Color.Red, Decoration.Bold, "The bigger the exponent, the faster the sequence grows.") ]
           Payloads [ P "Under the table"; panel "Wow" (E "ye-haw") ] 
           Strings [ "Sum"; "Last" ]
           Numbers [ 55; 10 ]
         ]
-        |> customTable { defaultTableLayout with Sizing = Collapse; Border = Spectre.Console.TableBorder.DoubleEdge; HideHeaders = true } columns
+        |> customTable { defaultTableLayout with Sizing = Collapse; Border = TableBorder.DoubleEdge; HideHeaders = true } columns
         |> withTitle "Tables can be nested, contain other Payloads, have titles ..."
         |> withCaption "..., have footers, captions, be customized, ..."
         |> toOutputPayload

--- a/src/spectrecoff-cli/commands/Table.fs
+++ b/src/spectrecoff-cli/commands/Table.fs
@@ -41,7 +41,7 @@ type TableExample() =
             |> withFooter (Pumped "Footer works, too!") 
             |> withLayout { defaultColumnLayout with Alignment = Right }
         ]
-        [ Payloads [ exampleTable.toOutputPayload;  MCS (Color.Red, Decoration.Bold, "The bigger the exponent, the faster the sequence grows.") ]
+        [ Payloads [ exampleTable.toOutputPayload;  MCS (Color.Red, [ Decoration.Bold ], "The bigger the exponent, the faster the sequence grows.") ]
           Payloads [ P "Under the table"; panel "Wow" (E "ye-haw") ] 
           Strings [ "Sum"; "Last" ]
           Numbers [ 55; 10 ]

--- a/src/spectrecoff-cli/commands/Table.fs
+++ b/src/spectrecoff-cli/commands/Table.fs
@@ -41,7 +41,7 @@ type TableExample() =
             |> withFooter (Pumped "Footer works, too!") 
             |> withLayout { defaultColumnLayout with Alignment = Right }
         ]
-        [ Payloads [ exampleTable.toOutputPayload;  MCS (Color.Red, [ Decoration.Bold ], "The bigger the exponent, the faster the sequence grows.") ]
+        [ Payloads [ exampleTable.toOutputPayload;  MCD (Color.Red, [ Decoration.Bold ], "The bigger the exponent, the faster the sequence grows.") ]
           Payloads [ P "Under the table"; panel "Wow" (E "ye-haw") ] 
           Strings [ "Sum"; "Last" ]
           Numbers [ 55; 10 ]

--- a/src/spectrecoff-cli/theming/Themes.fs
+++ b/src/spectrecoff-cli/theming/Themes.fs
@@ -8,9 +8,13 @@ module Theme =
 
     let setDocumentationStyle = 
         bulletItemPrefix <- "   >> "
-        pumpedColor <- Color.Yellow
-        pumpedStyle <- Italic
+        
+        pumpedLook <- 
+            { Color = Color.Yellow
+              Decoration = Decoration.Italic }
 
-        edgyColor <- Color.OrangeRed1
-        edgyStyle <- Italic
+        edgyLook <- 
+            { Color = Color.OrangeRed1
+              Decoration = Decoration.Italic }
+        
         ()

--- a/src/spectrecoff-cli/theming/Themes.fs
+++ b/src/spectrecoff-cli/theming/Themes.fs
@@ -11,10 +11,12 @@ module Theme =
         
         pumpedLook <- 
             { Color = Color.Yellow
+              BackgroundColor = None
               Decorations = [ Decoration.Italic ] }
 
         edgyLook <- 
             { Color = Color.OrangeRed1
+              BackgroundColor = None
               Decorations = [ Decoration.Italic ] }
         
         ()

--- a/src/spectrecoff-cli/theming/Themes.fs
+++ b/src/spectrecoff-cli/theming/Themes.fs
@@ -11,10 +11,10 @@ module Theme =
         
         pumpedLook <- 
             { Color = Color.Yellow
-              Decoration = [ Decoration.Italic ] }
+              Decorations = [ Decoration.Italic ] }
 
         edgyLook <- 
             { Color = Color.OrangeRed1
-              Decoration = [ Decoration.Italic ] }
+              Decorations = [ Decoration.Italic ] }
         
         ()

--- a/src/spectrecoff-cli/theming/Themes.fs
+++ b/src/spectrecoff-cli/theming/Themes.fs
@@ -11,10 +11,10 @@ module Theme =
         
         pumpedLook <- 
             { Color = Color.Yellow
-              Decoration = Decoration.Italic }
+              Decoration = [ Decoration.Italic ] }
 
         edgyLook <- 
             { Color = Color.OrangeRed1
-              Decoration = Decoration.Italic }
+              Decoration = [ Decoration.Italic ] }
         
         ()

--- a/src/spectrecoff/Calendar.fs
+++ b/src/spectrecoff/Calendar.fs
@@ -38,8 +38,8 @@ type CalendarSettings =
 let defaultCalendarSettings =
     {  Culture =  None
        HideHeaders = false
-       HeaderLook = { calmLook with Decoration = [ Decoration.Bold ] }
-       HighlightLook = { pumpedLook with Decoration = [ Decoration.Invert ] } }
+       HeaderLook = { calmLook with Decorations = [ Decoration.Bold ] }
+       HighlightLook = { pumpedLook with Decorations = [ Decoration.Invert ] } }
 
 let addEvent event (calendar: Calendar) =
     event

--- a/src/spectrecoff/Calendar.fs
+++ b/src/spectrecoff/Calendar.fs
@@ -38,8 +38,8 @@ type CalendarSettings =
 let defaultCalendarSettings =
     {  Culture =  None
        HideHeaders = false
-       HeaderLook = { calmLook with Decoration = Decoration.Bold }
-       HighlightLook = { pumpedLook with Decoration = Decoration.Invert } }
+       HeaderLook = { calmLook with Decoration = [ Decoration.Bold ] }
+       HighlightLook = { pumpedLook with Decoration = [ Decoration.Invert ] } }
 
 let addEvent event (calendar: Calendar) =
     event

--- a/src/spectrecoff/Calendar.fs
+++ b/src/spectrecoff/Calendar.fs
@@ -32,18 +32,14 @@ module Event =
 type CalendarSettings =
     {  Culture: Culture Option;
        HideHeaders: bool;
-       HeaderColor: Color;
-       HeaderStyle: Decoration;
-       HighlightColor: Color Option
-       HighlightStyle: Decoration Option }
+       HeaderLook: Look;
+       HighlightLook: Look; }
 
 let defaultCalendarSettings =
     {  Culture =  None
        HideHeaders = false
-       HeaderColor = calmColor
-       HeaderStyle = Decoration.Bold
-       HighlightColor = Some pumpedColor
-       HighlightStyle = Some Decoration.Invert }
+       HeaderLook = { calmLook with Decoration = Decoration.Bold }
+       HighlightLook = { pumpedLook with Decoration = Decoration.Invert } }
 
 let addEvent event (calendar: Calendar) =
     event
@@ -56,14 +52,8 @@ let applysettings (settings: CalendarSettings) (calendar: Calendar) =
     | _ -> ()
 
     calendar.ShowHeader <- not settings.HideHeaders
-    calendar.HeaderStyle <- Style (settings.HeaderColor, System.Nullable(), settings.HeaderStyle)
-
-    match (settings.HighlightColor, settings.HighlightStyle) with
-    | Some color, Some style -> calendar.HightlightStyle <- Style (color, System.Nullable(), style)
-    | Some color, None -> calendar.HightlightStyle <- Style (color)
-    | None, Some style -> calendar.HightlightStyle <- Style (System.Nullable(), System.Nullable(), style)
-    | _ -> ()
-
+    calendar.HeaderStyle <- toStyle settings.HeaderLook
+    calendar.HightlightStyle <- toStyle settings.HighlightLook
     calendar
 
 let customCalendar settings year month =

--- a/src/spectrecoff/Calendar.fs
+++ b/src/spectrecoff/Calendar.fs
@@ -52,8 +52,8 @@ let applysettings (settings: CalendarSettings) (calendar: Calendar) =
     | _ -> ()
 
     calendar.ShowHeader <- not settings.HideHeaders
-    calendar.HeaderStyle <- toStyle settings.HeaderLook
-    calendar.HightlightStyle <- toStyle settings.HighlightLook
+    calendar.HeaderStyle <- toSpectreStyle settings.HeaderLook
+    calendar.HightlightStyle <- toSpectreStyle settings.HighlightLook
     calendar
 
 let customCalendar settings year month =

--- a/src/spectrecoff/Figlet.fs
+++ b/src/spectrecoff/Figlet.fs
@@ -6,7 +6,7 @@ open SpectreCoff.Layout
 open SpectreCoff.Output
 
 let mutable defaultAlignment = Center
-let mutable defaultColor = pumpedColor
+let mutable defaultColor = pumpedLook.Color
 
 let customFiglet (alignment: Alignment) (color: Color) content = 
     let figlet = FigletText content

--- a/src/spectrecoff/Json.fs
+++ b/src/spectrecoff/Json.fs
@@ -7,39 +7,39 @@ open SpectreCoff.Output
 
 let mutable bracesLook = 
     { Color = calmLook.Color
-      Decoration = [ Decoration.None ] }
+      Decorations = [ Decoration.None ] }
 
 let mutable bracketsLook = 
     { Color = calmLook.Color
-      Decoration = [ Decoration.None ] }
+      Decorations = [ Decoration.None ] }
 
 let mutable colonLook = 
     { Color = calmLook.Color
-      Decoration = [ Decoration.None ] }
+      Decorations = [ Decoration.None ] }
 
 let mutable commaLook = 
     { Color = calmLook.Color
-      Decoration = [ Decoration.None ] }
+      Decorations = [ Decoration.None ] }
 
 let mutable memberLook = 
     { Color = pumpedLook.Color
-      Decoration = [ Decoration.Italic ] }
+      Decorations = [ Decoration.Italic ] }
 
 let mutable stringLook = 
     { Color = edgyLook.Color
-      Decoration = [ Decoration.Bold ] }
+      Decorations = [ Decoration.Bold ] }
 
 let mutable numberLook = 
     { Color = edgyLook.Color
-      Decoration = [ Decoration.Bold ] }
+      Decorations = [ Decoration.Bold ] }
 
 let mutable booleanLook = 
     { Color = calmLook.Color
-      Decoration = [ Decoration.Bold ] }
+      Decorations = [ Decoration.Bold ] }
 
 let mutable nullLook = 
     { Color = calmLook.Color
-      Decoration = [ Decoration.Dim ] }
+      Decorations = [ Decoration.Dim ] }
 
 
 let private aggregate decorations =

--- a/src/spectrecoff/Json.fs
+++ b/src/spectrecoff/Json.fs
@@ -7,54 +7,59 @@ open SpectreCoff.Output
 
 let mutable bracesLook = 
     { Color = calmLook.Color
+      BackgroundColor = None
       Decorations = [ Decoration.None ] }
 
 let mutable bracketsLook = 
     { Color = calmLook.Color
+      BackgroundColor = None
       Decorations = [ Decoration.None ] }
 
 let mutable colonLook = 
     { Color = calmLook.Color
+      BackgroundColor = None
       Decorations = [ Decoration.None ] }
 
 let mutable commaLook = 
     { Color = calmLook.Color
+      BackgroundColor = None
       Decorations = [ Decoration.None ] }
 
 let mutable memberLook = 
     { Color = pumpedLook.Color
+      BackgroundColor = None
       Decorations = [ Decoration.Italic ] }
 
 let mutable stringLook = 
     { Color = edgyLook.Color
+      BackgroundColor = None
       Decorations = [ Decoration.Bold ] }
 
 let mutable numberLook = 
     { Color = edgyLook.Color
+      BackgroundColor = None
       Decorations = [ Decoration.Bold ] }
 
 let mutable booleanLook = 
     { Color = calmLook.Color
+      BackgroundColor = None
       Decorations = [ Decoration.Bold ] }
 
 let mutable nullLook = 
     { Color = calmLook.Color
+      BackgroundColor = None
       Decorations = [ Decoration.Dim ] }
 
-
-let private aggregate decorations =
-    decorations |>  List.reduce (|||)
-
 let private applyStyles (json: JsonText) =
-    json.BracesStyle <- toStyle bracesLook
-    json.BracketsStyle <- toStyle bracketsLook
-    json.ColonStyle <- toStyle colonLook
-    json.CommaStyle <- toStyle commaLook
-    json.StringStyle <- toStyle stringLook
-    json.NumberStyle <- toStyle numberLook
-    json.BooleanStyle <- toStyle booleanLook
-    json.MemberStyle <- toStyle memberLook
-    json.NullStyle <- toStyle nullLook
+    json.BracesStyle <- toSpectreStyle bracesLook
+    json.BracketsStyle <- toSpectreStyle bracketsLook
+    json.ColonStyle <- toSpectreStyle colonLook
+    json.CommaStyle <- toSpectreStyle commaLook
+    json.StringStyle <- toSpectreStyle stringLook
+    json.NumberStyle <- toSpectreStyle numberLook
+    json.BooleanStyle <- toSpectreStyle booleanLook
+    json.MemberStyle <- toSpectreStyle memberLook
+    json.NullStyle <- toSpectreStyle nullLook
     json
 
 let json content = 

--- a/src/spectrecoff/Json.fs
+++ b/src/spectrecoff/Json.fs
@@ -5,31 +5,31 @@ open Spectre.Console
 open Spectre.Console.Json
 open SpectreCoff.Output
 
-let mutable bracesColor = calmColor
+let mutable bracesColor = calmLook.Color
 let mutable bracesDecorations = [ Decoration.None ]
 
-let mutable bracketsColor = calmColor
+let mutable bracketsColor = calmLook.Color
 let mutable bracketsDecorations = [ Decoration.None ]
 
-let mutable colonColor = calmColor
+let mutable colonColor = calmLook.Color
 let mutable colonDecorations = [ Decoration.None ]
 
-let mutable commaColor = calmColor
+let mutable commaColor = calmLook.Color
 let mutable commaDecorations = [ Decoration.None ]
 
-let mutable memberColor = pumpedColor
+let mutable memberColor = pumpedLook.Color
 let mutable memberDecorations = [ Decoration.Italic ]
 
-let mutable stringColor = edgyColor
+let mutable stringColor = edgyLook.Color
 let mutable stringDecorations = [ Decoration.Bold ]
 
-let mutable numberColor = edgyColor
+let mutable numberColor = edgyLook.Color
 let mutable numberDecorations = [ Decoration.Bold ]
 
-let mutable booleanColor = calmColor
+let mutable booleanColor = calmLook.Color
 let mutable booleanDecorations = [ Decoration.Bold ]
 
-let mutable nullColor = calmColor
+let mutable nullColor = calmLook.Color
 let mutable nullDecorations = [ Decoration.Dim ]
 
 let private aggregate decorations =

--- a/src/spectrecoff/Json.fs
+++ b/src/spectrecoff/Json.fs
@@ -5,46 +5,56 @@ open Spectre.Console
 open Spectre.Console.Json
 open SpectreCoff.Output
 
-let mutable bracesColor = calmLook.Color
-let mutable bracesDecorations = [ Decoration.None ]
+let mutable bracesLook = 
+    { Color = calmLook.Color
+      Decoration = [ Decoration.None ] }
 
-let mutable bracketsColor = calmLook.Color
-let mutable bracketsDecorations = [ Decoration.None ]
+let mutable bracketsLook = 
+    { Color = calmLook.Color
+      Decoration = [ Decoration.None ] }
 
-let mutable colonColor = calmLook.Color
-let mutable colonDecorations = [ Decoration.None ]
+let mutable colonLook = 
+    { Color = calmLook.Color
+      Decoration = [ Decoration.None ] }
 
-let mutable commaColor = calmLook.Color
-let mutable commaDecorations = [ Decoration.None ]
+let mutable commaLook = 
+    { Color = calmLook.Color
+      Decoration = [ Decoration.None ] }
 
-let mutable memberColor = pumpedLook.Color
-let mutable memberDecorations = [ Decoration.Italic ]
+let mutable memberLook = 
+    { Color = pumpedLook.Color
+      Decoration = [ Decoration.Italic ] }
 
-let mutable stringColor = edgyLook.Color
-let mutable stringDecorations = [ Decoration.Bold ]
+let mutable stringLook = 
+    { Color = edgyLook.Color
+      Decoration = [ Decoration.Bold ] }
 
-let mutable numberColor = edgyLook.Color
-let mutable numberDecorations = [ Decoration.Bold ]
+let mutable numberLook = 
+    { Color = edgyLook.Color
+      Decoration = [ Decoration.Bold ] }
 
-let mutable booleanColor = calmLook.Color
-let mutable booleanDecorations = [ Decoration.Bold ]
+let mutable booleanLook = 
+    { Color = calmLook.Color
+      Decoration = [ Decoration.Bold ] }
 
-let mutable nullColor = calmLook.Color
-let mutable nullDecorations = [ Decoration.Dim ]
+let mutable nullLook = 
+    { Color = calmLook.Color
+      Decoration = [ Decoration.Dim ] }
+
 
 let private aggregate decorations =
     decorations |>  List.reduce (|||)
 
 let private applyStyles (json: JsonText) =
-    json.BracesStyle <- Style (bracesColor, System.Nullable(), aggregate bracesDecorations)
-    json.BracketsStyle <- Style (bracketsColor, System.Nullable(), aggregate bracesDecorations)
-    json.ColonStyle <- Style (colonColor, System.Nullable(), aggregate colonDecorations)
-    json.CommaStyle <- Style (commaColor, System.Nullable(), aggregate commaDecorations)
-    json.StringStyle <- Style (stringColor, System.Nullable(), aggregate stringDecorations)
-    json.NumberStyle <- Style (numberColor, System.Nullable(), aggregate numberDecorations)
-    json.BooleanStyle <- Style (booleanColor, System.Nullable(), aggregate booleanDecorations)
-    json.MemberStyle <- Style (memberColor, System.Nullable(), aggregate memberDecorations)
-    json.NullStyle <- Style (nullColor, System.Nullable(), aggregate nullDecorations)
+    json.BracesStyle <- toStyle bracesLook
+    json.BracketsStyle <- toStyle bracketsLook
+    json.ColonStyle <- toStyle colonLook
+    json.CommaStyle <- toStyle commaLook
+    json.StringStyle <- toStyle stringLook
+    json.NumberStyle <- toStyle numberLook
+    json.BooleanStyle <- toStyle booleanLook
+    json.MemberStyle <- toStyle memberLook
+    json.NullStyle <- toStyle nullLook
     json
 
 let json content = 

--- a/src/spectrecoff/Layout.fs
+++ b/src/spectrecoff/Layout.fs
@@ -16,12 +16,19 @@ type Padding =
     | TopRightBottomLeft of int*int*int*int
 
 open Spectre.Console
+
 type Look = 
     { Decorations: Decoration list;
-      Color: Color }
+      Color: Color;
+      BackgroundColor: Color Option }
 
 let private aggregate decorations =
     decorations |>  List.reduce (|||)
 
-let toStyle look = 
-    Style (look.Color, System.Nullable(), aggregate look.Decorations)
+let toSpectreStyle look =
+    let backgroundColor = 
+        match look.BackgroundColor with
+        | Some color -> System.Nullable<Color> color
+        | None -> System.Nullable()
+
+    Style (look.Color, backgroundColor, aggregate look.Decorations)

--- a/src/spectrecoff/Layout.fs
+++ b/src/spectrecoff/Layout.fs
@@ -1,8 +1,6 @@
 [<AutoOpen>]
 module SpectreCoff.Layout
 
-
-
 type Alignment =
     | Left
     | Center
@@ -17,33 +15,13 @@ type Padding =
     | HorizontalVertical of int*int
     | TopRightBottomLeft of int*int*int*int
 
-type Style = 
-    | Bold
-    | Dim
-    | Italic
-    | Underline
-    | Invert
-    | Conceal
-    | Slowblink
-    | Rapidblink
-    | StrikeThrough
-
-let stringifyStyle style = 
-    match style with
-    | Bold -> "bold"
-    | Dim -> "dim"
-    | Italic -> "italic"
-    | Underline -> "underline"
-    | Invert -> "invert"
-    | Conceal -> "conceal"
-    | Slowblink -> "slowblink"
-    | Rapidblink -> "rapidblink"
-    | StrikeThrough -> "strikethrough"
-
 open Spectre.Console
 type Look = 
-    { Decoration: Decoration;
+    { Decoration: Decoration list;
       Color: Color }
 
+let private aggregate decorations =
+    decorations |>  List.reduce (|||)
+
 let toStyle look = 
-    Style (look.Color, System.Nullable(), look.Decoration)
+    Style (look.Color, System.Nullable(), aggregate look.Decoration)

--- a/src/spectrecoff/Layout.fs
+++ b/src/spectrecoff/Layout.fs
@@ -17,11 +17,11 @@ type Padding =
 
 open Spectre.Console
 type Look = 
-    { Decoration: Decoration list;
+    { Decorations: Decoration list;
       Color: Color }
 
 let private aggregate decorations =
     decorations |>  List.reduce (|||)
 
 let toStyle look = 
-    Style (look.Color, System.Nullable(), aggregate look.Decoration)
+    Style (look.Color, System.Nullable(), aggregate look.Decorations)

--- a/src/spectrecoff/Layout.fs
+++ b/src/spectrecoff/Layout.fs
@@ -1,6 +1,8 @@
 [<AutoOpen>]
 module SpectreCoff.Layout
 
+
+
 type Alignment =
     | Left
     | Center
@@ -37,3 +39,11 @@ let stringifyStyle style =
     | Slowblink -> "slowblink"
     | Rapidblink -> "rapidblink"
     | StrikeThrough -> "strikethrough"
+
+open Spectre.Console
+type Look = 
+    { Decoration: Decoration;
+      Color: Color }
+
+let toStyle look = 
+    Style (look.Color, System.Nullable(), look.Decoration)

--- a/src/spectrecoff/Output.fs
+++ b/src/spectrecoff/Output.fs
@@ -6,16 +6,18 @@ open Spectre.Console
 open System
 
 // Styles
-let mutable calmStyle = None
-let mutable calmColor = Color.SteelBlue
+let mutable calmLook: Look = 
+    { Color = Color.SteelBlue
+      Decoration = Decoration.None }
+let mutable pumpedLook: Look = 
+    { Color = Color.DeepSkyBlue3_1
+      Decoration = Decoration.Italic }
 
-let mutable pumpedStyle = Italic
-let mutable pumpedColor = Color.DeepSkyBlue3_1
+let mutable edgyLook: Look = 
+    { Color = Color.DarkTurquoise
+      Decoration = Decoration.Bold }
 
-let mutable edgyStyle = Bold
-let mutable edgyColor = Color.DarkTurquoise
-
-let mutable linkColor = pumpedColor
+let mutable linkColor = pumpedLook.Color
 
 // Special strings
 let mutable bulletItemPrefix = " + "
@@ -35,7 +37,7 @@ let private padEmoji (emoji: string) =
     | true -> emoji
     | false -> $":{emoji}:"
 
-let markupString (color: Color option) (style: Layout.Style option) content =
+let markupString (color: Color option) (style: Decoration option) content =
     match style with
     | None ->
         match color with
@@ -44,11 +46,11 @@ let markupString (color: Color option) (style: Layout.Style option) content =
     | Some s ->
         match color with
         | None -> markupWithStyle s content
-        | Some c -> markupWithColorAndStyle c (stringifyStyle s) content
+        | Some c -> markupWithColorAndStyle c (s.ToString()) content
 
-let pumped content = markupString (Some pumpedColor) (Some pumpedStyle) content
-let edgy content = markupString (Some edgyColor) (Some edgyStyle) content
-let calm content = markupString (Some calmColor) calmStyle content
+let pumped content = content |> markupString (Some pumpedLook.Color) (Some pumpedLook.Decoration)
+let edgy content = content |> markupString (Some edgyLook.Color) (Some edgyLook.Decoration)
+let calm content = content |> markupString (Some calmLook.Color)  (Some calmLook.Decoration)
 
 let printMarkedUpInline content = AnsiConsole.Markup $"{content}"
 let printMarkedUp content = AnsiConsole.Markup $"{content}{Environment.NewLine}"
@@ -67,9 +69,9 @@ let appendNewline content =
 
 type OutputPayload =
     | NewLine
-    | MarkupCS of Color * Layout.Style * string
+    | MarkupCS of Color * Decoration * string
     | MarkupC of Color * string
-    | MarkupS of Layout.Style * string
+    | MarkupS of Decoration * string
     | Link of string
     | LinkWithLabel of string*string
     | Emoji of string
@@ -105,9 +107,9 @@ let rec toMarkedUpString (payload: OutputPayload) =
     | Pumped content -> content |> pumped
     | Edgy content -> content |> edgy
     | Vanilla content -> content
-    | MarkupCS (color, style, content) -> content |> markupString (Some color) (Some style)
+    | MarkupCS (color, decoration, content) -> content |> markupString (Some color) (Some decoration)
     | MarkupC (color, content) -> content |> markupString (Some color) None
-    | MarkupS (style, content) -> content |> markupString None (Some style)
+    | MarkupS (decoration, content) -> content |> markupString None (Some decoration)
     | Link link -> link |> markupWithColorAndStyle linkColor "link"
     | LinkWithLabel (label, link) -> label |> markupWithColorAndStyle linkColor $"link={link}"
     | Emoji emoji -> emoji |> padEmoji

--- a/src/spectrecoff/Output.fs
+++ b/src/spectrecoff/Output.fs
@@ -8,17 +8,22 @@ open System
 // Styles
 let mutable calmLook: Look = 
     { Color = Color.SteelBlue
+      BackgroundColor = None
       Decorations = [ Decoration.None ] }
+
 let mutable pumpedLook: Look = 
     { Color = Color.DeepSkyBlue3_1
+      BackgroundColor = None
       Decorations = [ Decoration.Italic ]}
 
 let mutable edgyLook: Look = 
     { Color = Color.DarkTurquoise
+      BackgroundColor = None
       Decorations = [ Decoration.Bold ] }
 
 let mutable linkLook = 
     { Color = pumpedLook.Color
+      BackgroundColor = None
       Decorations = [ Decoration.Underline; Decoration.Italic ] }
 
 let mutable bulletItemPrefix = " + "

--- a/src/spectrecoff/Panel.fs
+++ b/src/spectrecoff/Panel.fs
@@ -13,7 +13,7 @@ type PanelLayout =
 
 let mutable defaultPanelLayout: PanelLayout =
     { Border = BoxBorder.Rounded
-      BorderColor = edgyColor
+      BorderColor = edgyLook.Color
       Sizing = Collapse
       Padding = AllEqual 2 }
 

--- a/src/spectrecoff/Table.fs
+++ b/src/spectrecoff/Table.fs
@@ -137,11 +137,11 @@ let customTable (layout: TableLayout) (columnDefinitions: ColumnDefinition list)
     table
 
 let withCaption caption (table: Table) =
-    table.Caption <- TableTitle (caption, Style (calmLook.Color, System.Nullable(), System.Nullable()))
+    table.Caption <- TableTitle (caption, toStyle { calmLook with Decoration = [] })
     table
 
 let withTitle title (table: Table) =
-    table.Title <- TableTitle (title, Style (pumpedLook.Color, System.Nullable(), System.Nullable()))
+    table.Title <- TableTitle (title, toStyle { pumpedLook with Decoration = [] })
     table
 
 let table =

--- a/src/spectrecoff/Table.fs
+++ b/src/spectrecoff/Table.fs
@@ -137,11 +137,11 @@ let customTable (layout: TableLayout) (columnDefinitions: ColumnDefinition list)
     table
 
 let withCaption caption (table: Table) =
-    table.Caption <- TableTitle (caption, toStyle { calmLook with Decorations = [] })
+    table.Caption <- TableTitle (caption, toSpectreStyle { calmLook with Decorations = [] })
     table
 
 let withTitle title (table: Table) =
-    table.Title <- TableTitle (title, toStyle { pumpedLook with Decorations = [] })
+    table.Title <- TableTitle (title, toSpectreStyle { pumpedLook with Decorations = [] })
     table
 
 let table =

--- a/src/spectrecoff/Table.fs
+++ b/src/spectrecoff/Table.fs
@@ -137,11 +137,11 @@ let customTable (layout: TableLayout) (columnDefinitions: ColumnDefinition list)
     table
 
 let withCaption caption (table: Table) =
-    table.Caption <- TableTitle (caption, Style (calmColor, System.Nullable(), System.Nullable()))
+    table.Caption <- TableTitle (caption, Style (calmLook.Color, System.Nullable(), System.Nullable()))
     table
 
 let withTitle title (table: Table) =
-    table.Title <- TableTitle (title, Style (pumpedColor, System.Nullable(), System.Nullable()))
+    table.Title <- TableTitle (title, Style (pumpedLook.Color, System.Nullable(), System.Nullable()))
     table
 
 let table =

--- a/src/spectrecoff/Table.fs
+++ b/src/spectrecoff/Table.fs
@@ -137,11 +137,11 @@ let customTable (layout: TableLayout) (columnDefinitions: ColumnDefinition list)
     table
 
 let withCaption caption (table: Table) =
-    table.Caption <- TableTitle (caption, toStyle { calmLook with Decoration = [] })
+    table.Caption <- TableTitle (caption, toStyle { calmLook with Decorations = [] })
     table
 
 let withTitle title (table: Table) =
-    table.Title <- TableTitle (title, toStyle { pumpedLook with Decoration = [] })
+    table.Title <- TableTitle (title, toStyle { pumpedLook with Decorations = [] })
     table
 
 let table =

--- a/src/spectrecoff/Textpath.fs
+++ b/src/spectrecoff/Textpath.fs
@@ -5,10 +5,10 @@ open Spectre.Console
 open SpectreCoff.Layout
 open SpectreCoff.Output
 
-let mutable stemColor = calmColor
-let mutable rootColor = calmColor
-let mutable separatorColor = pumpedColor
-let mutable leafColor = edgyColor
+let mutable stemColor = calmLook.Color
+let mutable rootColor = calmLook.Color
+let mutable separatorColor = pumpedLook.Color
+let mutable leafColor = edgyLook.Color
 
 let mutable defaultAlignment = Left
 

--- a/src/spectrecoff/Tree.fs
+++ b/src/spectrecoff/Tree.fs
@@ -21,7 +21,7 @@ type TreeLayout =
 let defaultTreeLayout: TreeLayout =
     {  Sizing = Collapse
        Guides = SingleLine
-       ForeGroundColor = Some calmColor
+       ForeGroundColor = Some calmLook.Color
        BackGroundColor = None
        Decoration = None }
 


### PR DESCRIPTION
_Style_ and _Color_ always go together when marking up strings in Spectreconsole. With this PR, we introduce `Look ` - a record consisting of both properties. In a follow-up, we will add the `BackgroundColor` (used in the tree module) to this as well an enable it globally for a consistent styling experience.