### PR TITLE
Feature/symmetrize colors

### DIFF
--- a/src/spectrecoff-cli/commands/Calendar.fs
+++ b/src/spectrecoff-cli/commands/Calendar.fs
@@ -38,7 +38,7 @@ type CalendarExample() =
                   BackgroundColor = Some Color.Purple
                   Decorations = [ Decoration.Italic ] }
               HighlightLook = 
-                { Color = Color.Yellow
+                { Color = Some Color.Yellow
                   BackgroundColor = Some Color.Purple
                   Decorations = [ Decoration.Invert ] } }
 

--- a/src/spectrecoff-cli/commands/Output.fs
+++ b/src/spectrecoff-cli/commands/Output.fs
@@ -13,9 +13,9 @@ type OutputExample() =
 
     override _.Execute(_context, _) =
 
-        pumpedLook <- { pumpedLook with Color = Color.Fuchsia }
-        edgyLook <- { edgyLook with Color = Color.BlueViolet }
-        calmLook <- { calmLook with Color = Color.Green }
+        pumpedLook <- { pumpedLook with Color = Some Color.Fuchsia }
+        edgyLook <- { edgyLook with Color = Some Color.BlueViolet }
+        calmLook <- { calmLook with Color = Some Color.Green }
 
         NewLine |> toConsole
 

--- a/src/spectrecoff-cli/commands/Panel.fs
+++ b/src/spectrecoff-cli/commands/Panel.fs
@@ -34,7 +34,7 @@ type PanelExample() =
         |> toConsole    
 
         P "That surrounding border can be customized easily!"
-        |> customPanel { defaultPanelLayout with Sizing = Expand; BorderColor = Spectre.Console.Color.Yellow } " Customization " 
+        |> customPanel { defaultPanelLayout with Sizing = Expand; BorderColor = Some Spectre.Console.Color.Yellow } " Customization " 
         |> toConsole
         0
 

--- a/src/spectrecoff-cli/commands/Tree.fs
+++ b/src/spectrecoff-cli/commands/Tree.fs
@@ -29,10 +29,7 @@ type TreeExample() =
         |> toConsole
 
         customTree 
-            { defaultTreeLayout with 
-                ForeGroundColor = Some Color.Green 
-                BackGroundColor = Some Color.Grey
-                Decoration = Some Decoration.Bold } 
+            { defaultTreeLayout with Look = { Color = Some Color.Green; BackgroundColor = Some Color.Grey; Decorations = [Decoration.Bold] } }
             (P "Custom-Tree!") 
             [ for i in 1 .. 3 -> node (C $"Node {i}!") [] ] 
         |> toConsole

--- a/src/spectrecoff-cli/theming/Themes.fs
+++ b/src/spectrecoff-cli/theming/Themes.fs
@@ -10,13 +10,13 @@ module Theme =
         bulletItemPrefix <- "   >> "
         
         pumpedLook <- 
-            { Color = Color.Yellow
+            { Color = Some Color.Yellow
               BackgroundColor = None
               Decorations = [ Decoration.Italic ] }
 
         edgyLook <- 
-            { Color = Color.OrangeRed1
-              BackgroundColor = None
+            { Color = Some Color.DarkKhaki
+              BackgroundColor = Some Color.OrangeRed1
               Decorations = [ Decoration.Italic ] }
         
         ()

--- a/src/spectrecoff/Figlet.fs
+++ b/src/spectrecoff/Figlet.fs
@@ -8,18 +8,31 @@ open SpectreCoff.Output
 let mutable defaultAlignment = Center
 let mutable defaultColor = pumpedLook.Color
 
-let customFiglet (alignment: Alignment) (color: Color) content = 
-    let figlet = FigletText content
-    figlet.Color <- color
-
+let private applyAlignment alignment figlet = 
     match alignment with
     | Left -> figlet.LeftJustified() |> ignore
     | Center -> figlet.Centered() |> ignore
     | Right -> figlet.RightJustified() |> ignore
+    figlet
 
+let private toRenderable figlet = 
     figlet
     :> Rendering.IRenderable
     |> Renderable
 
-let figlet = 
-    customFiglet defaultAlignment defaultColor 
+let private applyColor (colorOption: Color Option) (figlet: FigletText) = 
+    match colorOption with 
+    | Some color ->  figlet.Color <- color
+    | None -> ()
+    figlet
+
+let customFiglet (alignment: Alignment) (color: Color) content = 
+    FigletText content
+    |> applyColor (Some color)
+    |> applyAlignment alignment
+    |> toRenderable
+
+let figlet content = 
+    FigletText content
+    |> applyAlignment defaultAlignment
+    |> toRenderable 

--- a/src/spectrecoff/Layout.fs
+++ b/src/spectrecoff/Layout.fs
@@ -25,15 +25,10 @@ type Look =
 let private aggregate decorations =
     decorations |>  List.reduce (|||)
 
-let toSpectreStyle look =
-    let backgroundColor = 
-        match look.BackgroundColor with
-        | Some color -> System.Nullable<Color> color
-        | None -> System.Nullable()
-    
-    let foregroundColor = 
-        match look.BackgroundColor with
-        | Some color -> System.Nullable<Color> color
-        | None -> System.Nullable()
+let private toNullable colorOption = 
+    match colorOption with 
+    | Some color -> System.Nullable<Color> color
+    | None -> System.Nullable()
 
-    Style (foregroundColor, backgroundColor, aggregate look.Decorations)
+let toSpectreStyle look =
+    Style (toNullable look.Color, toNullable look.BackgroundColor, aggregate look.Decorations)

--- a/src/spectrecoff/Layout.fs
+++ b/src/spectrecoff/Layout.fs
@@ -19,7 +19,7 @@ open Spectre.Console
 
 type Look = 
     { Decorations: Decoration list;
-      Color: Color;
+      Color: Color Option;
       BackgroundColor: Color Option }
 
 let private aggregate decorations =
@@ -30,5 +30,10 @@ let toSpectreStyle look =
         match look.BackgroundColor with
         | Some color -> System.Nullable<Color> color
         | None -> System.Nullable()
+    
+    let foregroundColor = 
+        match look.BackgroundColor with
+        | Some color -> System.Nullable<Color> color
+        | None -> System.Nullable()
 
-    Style (look.Color, backgroundColor, aggregate look.Decorations)
+    Style (foregroundColor, backgroundColor, aggregate look.Decorations)

--- a/src/spectrecoff/Output.fs
+++ b/src/spectrecoff/Output.fs
@@ -71,7 +71,7 @@ let markupString (colorOption: Color option) (decorations: Decoration list) cont
     markup $"{stringify colorOption None decorations}" content
 
 let markupLink link label =
-    let style = stringify (Some linkLook.Color) None linkLook.Decorations
+    let style = stringifyLook linkLook
     match label with
     | "" -> markup $"{style} link" link
     | _ -> markup $"{style} link={link}" label

--- a/src/spectrecoff/Panel.fs
+++ b/src/spectrecoff/Panel.fs
@@ -7,7 +7,7 @@ open SpectreCoff.Output
 
 type PanelLayout =
     { Border: BoxBorder;
-      BorderColor: Color;
+      BorderColor: Color Option;
       Sizing: SizingBehaviour;
       Padding: Padding }
 
@@ -17,12 +17,18 @@ let mutable defaultPanelLayout: PanelLayout =
       Sizing = Collapse
       Padding = AllEqual 2 }
 
-let customPanel (layout: PanelLayout) (header: string) (content: OutputPayload) =
-    let panel = Panel(content |> payloadToRenderable)
-    panel.Header <- PanelHeader(header)
+let private addHeader header (panel: Panel) = 
+   panel.Header <- PanelHeader(header)
+   panel
 
-    panel.Border <- layout.Border
-    panel.BorderColor layout.BorderColor |> ignore
+let private addBorder border (panel: Panel) = 
+   panel.Border <- border
+   panel
+
+let private applyLayout (layout: PanelLayout) (panel: Panel) = 
+    match layout.BorderColor with
+    | Some color -> panel.BorderColor color |> ignore
+    | None -> ()
 
     match layout.Sizing with
     | Expand -> panel.Expand <- true
@@ -32,10 +38,19 @@ let customPanel (layout: PanelLayout) (header: string) (content: OutputPayload) 
     | AllEqual value -> panel.Padding <- Spectre.Console.Padding(value)
     | HorizontalVertical (hor,vert) -> panel.Padding <- Spectre.Console.Padding(hor, vert)
     | TopRightBottomLeft (l,t,r,b) -> panel.Padding <- Spectre.Console.Padding(l, t, r, b)
+    panel  
 
+let private toRenderable panel = 
     panel
     :> Rendering.IRenderable
     |> Renderable
+
+let customPanel (layout: PanelLayout) (header: string) (content: OutputPayload) =
+    Panel(content |> payloadToRenderable)
+    |> addHeader header
+    |> addBorder layout.Border
+    |> applyLayout layout
+    |> toRenderable
 
 let panel =
    customPanel defaultPanelLayout

--- a/src/spectrecoff/Textpath.fs
+++ b/src/spectrecoff/Textpath.fs
@@ -5,31 +5,37 @@ open Spectre.Console
 open SpectreCoff.Layout
 open SpectreCoff.Output
 
-let mutable stemColor = calmLook.Color
-let mutable rootColor = calmLook.Color
-let mutable separatorColor = pumpedLook.Color
-let mutable leafColor = edgyLook.Color
+let mutable stemLook = calmLook
+let mutable rootLook = calmLook
+let mutable separatorLook = pumpedLook
+let mutable leafLook = edgyLook
 
 let mutable defaultAlignment = Left
 
-let private applyColors (path: TextPath) =
-    path.LeafColor leafColor |> ignore
-    path.SeparatorColor separatorColor |> ignore
-    path.StemColor stemColor |> ignore
-    path.RootColor rootColor
+let private applyLooks (path: TextPath) =
+    path.LeafStyle <- toSpectreStyle leafLook
+    path.SeparatorStyle <- toSpectreStyle separatorLook
+    path.RootStyle <- toSpectreStyle rootLook
+    path.StemStyle <- toSpectreStyle stemLook
+    path
 
-let alignedPath alignment value =
-    let path = TextPath value
-
+let private applyAlignment alignment path =
     match alignment with
     | Left -> path.LeftJustified() |> ignore
     | Center -> path.Centered() |> ignore
     | Right -> path.RightJustified() |> ignore
+    path
 
-    path 
-    |> applyColors 
+let private toRenderable path = 
+    path
     :> Rendering.IRenderable
     |> Renderable
+
+let alignedPath alignment value =
+    TextPath value
+    |> applyAlignment alignment 
+    |> applyLooks 
+    |> toRenderable
 
 let path = 
     alignedPath defaultAlignment

--- a/src/spectrecoff/Tree.fs
+++ b/src/spectrecoff/Tree.fs
@@ -12,18 +12,14 @@ type GuideStyle =
     | BoldLine
 
 type TreeLayout =
-    {  Sizing: SizingBehaviour
-       Guides: GuideStyle
-       ForeGroundColor: Color Option
-       BackGroundColor: Color Option
-       Decoration: Decoration Option}
+    { Sizing: SizingBehaviour
+      Guides: GuideStyle
+      Look: Look }
 
 let defaultTreeLayout: TreeLayout =
-    {  Sizing = Collapse
-       Guides = SingleLine
-       ForeGroundColor = Some calmLook.Color
-       BackGroundColor = None
-       Decoration = None }
+    { Sizing = Collapse
+      Guides = SingleLine
+      Look = calmLook }
 
 let private toNullable option =
     match option with
@@ -41,8 +37,13 @@ let private applyLayout layout (root: Tree) =
     | DoubleLine -> root.Guide <- TreeGuide.DoubleLine
     | BoldLine -> root.Guide <- TreeGuide.BoldLine
 
-    root.Style <- Style (toNullable layout.ForeGroundColor, toNullable layout.BackGroundColor, toNullable layout.Decoration)
+    root.Style <- toSpectreStyle layout.Look
     root
+
+let private toRenderable tree = 
+    tree
+    :> Rendering.IRenderable
+    |> Renderable
 
 let attach (nodes: TreeNode list) (node: TreeNode) =
     nodes |> List.iter (fun n -> node.AddNode n |> ignore)
@@ -64,8 +65,7 @@ let customTree (layout: TreeLayout) (rootContent: OutputPayload ) (nodes: TreeNo
     |> Tree
     |> applyLayout layout
     |> attachToRoot nodes
-    :> Rendering.IRenderable
-    |> Renderable
+    |> toRenderable
 
 let tree =
     customTree defaultTreeLayout


### PR DESCRIPTION
Full support for optional foreground color, too. Now, both are treated symmetrically, which opens up the full color and decoration styling potential offered by Spectre.Console.