### PR TITLE
Pack readme file with nuget package

### DIFF
--- a/src/spectrecoff/SpectreCoff.fsproj
+++ b/src/spectrecoff/SpectreCoff.fsproj
@@ -13,8 +13,12 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/EluciusFTW/SpectreCoff</PackageProjectUrl>
     <RepositoryUrl>https://github.com/EluciusFTW/SpectreCoff</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="../../README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="Styling.fs" />
     <Compile Include="Output.fs" />


### PR DESCRIPTION
[This](https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/) is my source. 

I verified that the readme now is part of the package, but I didn't push to nuget.org, I vote for a leap of faith :)

<img width="1910" alt="image" src="https://github.com/EluciusFTW/SpectreCoff/assets/17160319/657c0fe7-eb13-424e-a730-14ce409dd0af">
