### PR TITLE
Documentation/exrtact definitions

### DIFF
--- a/src/spectrecoff-cli/DocumentationUtilities.fs
+++ b/src/spectrecoff-cli/DocumentationUtilities.fs
@@ -5,10 +5,29 @@ open SpectreCoff.Theming
 
 module Documentation =
     open SpectreCoff
+
+    type Name = Name of string
+    type FunctionSignature = FunctionSignature of string
+
+    type PropertyType = PropertyType of string
+    type DefaultValue = DefaultValue of string
+    type Explanation = Explanation of string
+
+    type DocumentationArtifact = 
+        | FunctionDefinition of Name * FunctionSignature
+        | PropertyDefinition of Name * PropertyType * DefaultValue * Explanation
+
     let setDocumentationStyle =
         selectTheme Documentation
         bulletItemPrefix <- "   >> "
         ()
+
+    let toOutput artifact = 
+        match artifact with
+        | FunctionDefinition (Name n, FunctionSignature s) 
+            -> P $"{n}: {s}"
+        | PropertyDefinition (Name n, PropertyType t, DefaultValue d, Explanation e) 
+            -> Many [ P $"{n}: {t}"; C $"{e} ("; P $"{d}"; C")"]
 
     let define term explanation =
         Many [ P $"{term}:"; C explanation]

--- a/src/spectrecoff-cli/DocumentationUtilities.fs
+++ b/src/spectrecoff-cli/DocumentationUtilities.fs
@@ -22,12 +22,15 @@ module Documentation =
         bulletItemPrefix <- "   >> "
         ()
 
-    let toOutput artifact = 
+    let private toOutputPayload artifact = 
         match artifact with
         | FunctionDefinition (Name n, FunctionSignature s) 
             -> P $"{n}: {s}"
         | PropertyDefinition (Name n, PropertyType t, DefaultValue d, Explanation e) 
             -> Many [ P $"{n}: {t}"; C $"{e} ("; P $"{d}"; C")"]
+
+    let print artifacts = 
+        artifacts |> List.map toOutputPayload |> BI
 
     let define term explanation =
         Many [ P $"{term}:"; C explanation]

--- a/src/spectrecoff-cli/commands/Tree.fs
+++ b/src/spectrecoff-cli/commands/Tree.fs
@@ -42,9 +42,43 @@ type TreeDocumentation() =
     interface ICommandLimiter<TreeSettings>
 
     override _.Execute(_context, _) =
+
+        let treeFn = FunctionDefinition (Name "tree", FunctionSignature "OutputPayload -> TreeNode list -> OutputPayload")
+        let customTreeFn = FunctionDefinition (Name "customTree", FunctionSignature "TreeLayout -> OutputPayload -> TreeNode list -> OutputPayload")
+        let nodeFn = FunctionDefinition (Name "node", FunctionSignature "OutputPayload -> TreeNode list -> TreeNode")
+        let attachFn = FunctionDefinition (Name "attach", FunctionSignature "TreeNode list -> TreeNode -> TreeNode")
+        let attachToRootFn = FunctionDefinition (Name "attachToRoot", FunctionSignature "TreeNode list -> Tree -> Tree")
+
+        let sizingProp = PropertyDefinition (Name "Sizing", PropertyType "SizingBehaviour", DefaultValue "Collapse", Explanation "The sizing of the tree nodes")
+        let guidesProp = PropertyDefinition (Name "Guides", PropertyType "GuideStyle", DefaultValue "SingleLine", Explanation "The style of the lines")
+        let lookProp = PropertyDefinition (Name "Look", PropertyType "Look", DefaultValue "calmLook", Explanation "The look of the nodes")
+
         setDocumentationStyle
         Many[
             docSynopsis "Tree module" "This module provides functionality from the tree widget of Spectre.Console" "widgets/tree"
-            docMissing
+            C "A tree can be created by:"
+            BI [
+                toOutput treeFn
+                toOutput customTreeFn
+            ]
+            C "The first argument of type 'OutputPayload' is the content of the root node, and the 'TreeNode list' are the first level branches."
+            BL 
+            C "The 'TreeLayout' that can be provided consists of:"
+            BI [
+                toOutput sizingProp
+                toOutput guidesProp 
+                toOutput lookProp 
+            ]
+            BL
+            C "The 'TreeNode' instances are created similarily, using"
+            BI [
+                toOutput nodeFn
+            ]
+            BL
+            C "If you want to attach more nodes to the root or anotehr node later on, you can use one of these functions:"
+            BI [
+                toOutput attachFn
+                toOutput attachToRootFn
+            ]
         ] |> toConsole
         0

--- a/src/spectrecoff-cli/commands/Tree.fs
+++ b/src/spectrecoff-cli/commands/Tree.fs
@@ -59,28 +59,16 @@ type TreeDocumentation() =
         Many[
             docSynopsis "Tree module" "This module provides functionality from the tree widget of Spectre.Console" "widgets/tree"
             C "A tree can be created by:"
-            BI [
-                toOutput treeFn
-                toOutput customTreeFn
-            ]
+            print [treeFn; customTreeFn]
             C "The first argument of type 'OutputPayload' is the content of the root node, and the 'TreeNode list' are the first level branches."
             BL 
             C "The 'TreeLayout' that can be provided consists of:"
-            BI [
-                toOutput sizingProp
-                toOutput guidesProp 
-                toOutput lookProp 
-            ]
+            print [sizingProp; guidesProp; lookProp]
             BL
             C "The 'TreeNode' instances are created similarily, using"
-            BI [
-                toOutput nodeFn
-            ]
+            print [nodeFn]
             BL
             C "If you want to attach more nodes to the root or anotehr node later on, you can use one of these functions:"
-            BI [
-                toOutput attachFn
-                toOutput attachToRootFn
-            ]
+            print [attachFn; attachToRootFn]
         ] |> toConsole
         0

--- a/src/spectrecoff-cli/commands/Tree.fs
+++ b/src/spectrecoff-cli/commands/Tree.fs
@@ -26,12 +26,14 @@ type TreeExample() =
                 | _ -> node)
         
         tree (P "FizzBuzz-Tree!") nodes 
+        |> toOutputPayload 
         |> toConsole
 
         customTree 
             { defaultTreeLayout with Look = { Color = Some Color.Green; BackgroundColor = Some Color.Grey; Decorations = [Decoration.Bold] } }
             (P "Custom-Tree!") 
             [ for i in 1 .. 3 -> node (C $"Node {i}!") [] ] 
+        |> toOutputPayload
         |> toConsole
         0
 
@@ -43,8 +45,8 @@ type TreeDocumentation() =
 
     override _.Execute(_context, _) =
 
-        let treeFn = FunctionDefinition (Name "tree", FunctionSignature "OutputPayload -> TreeNode list -> OutputPayload")
-        let customTreeFn = FunctionDefinition (Name "customTree", FunctionSignature "TreeLayout -> OutputPayload -> TreeNode list -> OutputPayload")
+        let treeFn = FunctionDefinition (Name "tree", FunctionSignature "OutputPayload -> TreeNode list -> Tree")
+        let customTreeFn = FunctionDefinition (Name "customTree", FunctionSignature "TreeLayout -> OutputPayload -> TreeNode list -> Tree")
         let nodeFn = FunctionDefinition (Name "node", FunctionSignature "OutputPayload -> TreeNode list -> TreeNode")
         let attachFn = FunctionDefinition (Name "attach", FunctionSignature "TreeNode list -> TreeNode -> TreeNode")
         let attachToRootFn = FunctionDefinition (Name "attachToRoot", FunctionSignature "TreeNode list -> Tree -> Tree")

--- a/src/spectrecoff/Tree.fs
+++ b/src/spectrecoff/Tree.fs
@@ -21,11 +21,6 @@ let defaultTreeLayout: TreeLayout =
       Guides = SingleLine
       Look = calmLook }
 
-let private toNullable option =
-    match option with
-    | None -> System.Nullable<_> ()
-    | Some a -> System.Nullable<_> a
-
 let private applyLayout layout (root: Tree) =
     match layout.Sizing with
     | Expand -> root.Expanded <- true

--- a/src/spectrecoff/Tree.fs
+++ b/src/spectrecoff/Tree.fs
@@ -35,11 +35,6 @@ let private applyLayout layout (root: Tree) =
     root.Style <- toSpectreStyle layout.Look
     root
 
-let private toRenderable tree = 
-    tree
-    :> Rendering.IRenderable
-    |> Renderable
-
 let attach (nodes: TreeNode list) (node: TreeNode) =
     nodes |> List.iter (fun n -> node.AddNode n |> ignore)
     node
@@ -60,7 +55,9 @@ let customTree (layout: TreeLayout) (rootContent: OutputPayload ) (nodes: TreeNo
     |> Tree
     |> applyLayout layout
     |> attachToRoot nodes
-    |> toRenderable
 
 let tree =
     customTree defaultTreeLayout
+
+type Tree with
+    member self.toOutputPayload = toOutputPayload self


### PR DESCRIPTION
Thinking about separating view and data for documentation to give us some more flexibility in the future, and force the style to be consistent. What do you think?

It looks as expected: 
![image](https://github.com/EluciusFTW/SpectreCoff/assets/10219667/06910d0a-2474-4ef3-a0d1-0d666ff1a7f9)
