### PR TITLE
Upgrade/spectre 48 net 8

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/spectrecoff-cli/SpectreCoff.Cli.fsproj
+++ b/src/spectrecoff-cli/SpectreCoff.Cli.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>SpectreCoff.Cli</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
@@ -31,8 +31,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
-    <PackageReference Include="Spectre.Console" Version="0.47.0" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.47.0" />
+    <PackageReference Include="Spectre.Console" Version="0.48.0" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.48.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\spectrecoff\SpectreCoff.fsproj" />

--- a/src/spectrecoff/SpectreCoff.fsproj
+++ b/src/spectrecoff/SpectreCoff.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
     <RootNamespace>SpectreCoff</RootNamespace>
     <LangVersion>latest</LangVersion>
     <Authors>Guy Buss, Daniel Muckelbauer</Authors>
@@ -8,7 +8,7 @@
     <Title>SpectreCoff - Spectre.Console for FSharp</Title>
     <Description>A thin, opinionated wrapper around Spectre.Console in FSharp.</Description>
     <PackageTags>cli commandline console-application spectre spectre.console wrapper wrapper-api FSharp F#</PackageTags>
-    <PackageReleaseNotes> Added theming </PackageReleaseNotes>
+    <PackageReleaseNotes> Update to Spectre.Console 0.48 and .NET8 </PackageReleaseNotes>
     <PackageId>EluciusFTW.SpectreCoff</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/EluciusFTW/SpectreCoff</PackageProjectUrl>
@@ -46,9 +46,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Spectre.Console" Version="0.47.0" />
-    <PackageReference Include="Spectre.Console.ImageSharp" Version="0.47.0" />
-    <PackageReference Include="Spectre.Console.Json" Version="0.47.0" />
+    <PackageReference Include="Spectre.Console" Version="0.48.0" />
+    <PackageReference Include="Spectre.Console.ImageSharp" Version="0.48.0" />
+    <PackageReference Include="Spectre.Console.Json" Version="0.48.0" />
     <PackageReference Update="FSharp.Core" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.47",
+  "version": "0.48",
   "publicReleaseRefSpec": [ "^refs/heads/main$" ],
   "cloudBuild": {
     "setVersionVariables": true


### PR DESCRIPTION
Gotta upgrade, .NET8 is already out for a week, and spectre 0.48 since yesterday!
https://spectreconsole.net/blog/posts/2023-11-22-spectre-console-0.48-released
