### PR TITLE
Update spectre console to 49.1

### DIFF
--- a/src/spectrecoff-cli/SpectreCoff.Cli.fsproj
+++ b/src/spectrecoff-cli/SpectreCoff.Cli.fsproj
@@ -30,9 +30,9 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
-    <PackageReference Include="Spectre.Console" Version="0.48.0" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.48.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
+    <PackageReference Include="Spectre.Console" Version="0.49.1" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.49.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\spectrecoff\SpectreCoff.fsproj" />

--- a/src/spectrecoff/SpectreCoff.fsproj
+++ b/src/spectrecoff/SpectreCoff.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>SpectreCoff</RootNamespace>
     <LangVersion>latest</LangVersion>
     <Authors>Guy Buss, Daniel Muckelbauer</Authors>
@@ -8,7 +8,7 @@
     <Title>SpectreCoff - Spectre.Console for FSharp</Title>
     <Description>A thin, opinionated wrapper around Spectre.Console in FSharp.</Description>
     <PackageTags>cli commandline console-application spectre spectre.console wrapper wrapper-api FSharp F#</PackageTags>
-    <PackageReleaseNotes> Update to Spectre.Console 0.48 and .NET8 </PackageReleaseNotes>
+    <PackageReleaseNotes>Update to Spectre.Console 0.49.1</PackageReleaseNotes>
     <PackageId>EluciusFTW.SpectreCoff</PackageId>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/EluciusFTW/SpectreCoff</PackageProjectUrl>
@@ -40,14 +40,14 @@
     <Compile Include="Spectre\Tree.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Dumpify" Version="0.6.0" />
-    <PackageReference Include="Nerdbank.Gitversioning" Version="3.5.119">
+    <PackageReference Include="Dumpify" Version="0.6.5" />
+    <PackageReference Include="Nerdbank.Gitversioning" Version="3.6.133">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Spectre.Console" Version="0.48.0" />
-    <PackageReference Include="Spectre.Console.ImageSharp" Version="0.48.0" />
-    <PackageReference Include="Spectre.Console.Json" Version="0.48.0" />
+    <PackageReference Include="Spectre.Console" Version="0.49.1" />
+    <PackageReference Include="Spectre.Console.ImageSharp" Version="0.49.1" />
+    <PackageReference Include="Spectre.Console.Json" Version="0.49.1" />
     <PackageReference Update="FSharp.Core" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.48",
+  "version": "0.49",
   "publicReleaseRefSpec": [ "^refs/heads/main$" ],
   "cloudBuild": {
     "setVersionVariables": true


### PR DESCRIPTION
- Remove netstandard 2.0 target

![image](https://github.com/EluciusFTW/SpectreCoff/assets/17160319/6b91827a-189f-4b98-b48f-5b68b4658cdc)
