### PR TITLE
Status with Async<'a>

### DIFF
--- a/docs/modules/status.md
+++ b/docs/modules/status.md
@@ -2,18 +2,21 @@
 
 ### Example
 ```fs
-let process (context: StatusContext) =
-    task {
-        do! Task.Delay(3000)
+let operation (context: StatusContext) =
+    async {
+        do! Async.Sleep 500
         update "Halfway there ..." context |> ignore
 
-        do! Task.Delay(3000)
+        do! Async.Sleep 500
         update "Any Moment now ..." context |> ignore
 
-        do! Task.Delay(3000)
+        do! Async.Sleep 500
+        return "Done!"
     }
 
-(start "Starting up ..." process).Wait()
+(Status.start "Starting up ..." operation) 
+|> Async.RunSynchronously
+|> P |> toConsole
 ```
 
 ### Cli Example

--- a/src/spectrecoff-cli/commands/Status.fs
+++ b/src/spectrecoff-cli/commands/Status.fs
@@ -1,6 +1,6 @@
 namespace SpectreCoff.Cli.Commands
 
-open System.Threading.Tasks
+open System
 open Spectre.Console
 open Spectre.Console.Cli
 open SpectreCoff
@@ -14,30 +14,38 @@ type StatusExample() =
 
     override _.Execute(_context, _settings) =
         let normalThinkingSpinner: CustomSpinner =
-           { Message = "Thinking"
-             Spinner = Some Spinner.Known.Pong
-             Look = Some { calmLook with Color = Some Color.Green } }
+            { Message = "Thinking"
+              Spinner = Some Spinner.Known.Pong
+              Look = Some { calmLook with Color = Some Color.Green } }
 
-        let thinkingProcess (context: StatusContext) =
-            task {
-                do! Task.Delay(3000)
-                let harderThinkingSpinner =
-                    { normalThinkingSpinner with
-                        Message = "Thinking harder..."
-                        Look = Some { calmLook with Color = Some Color.DarkOrange } }
+        let harderThinkingSpinner =
+                   { normalThinkingSpinner with
+                       Message = "Thinking harder..."
+                       Look = Some { calmLook with Color = Some Color.DarkOrange } }
+
+        let maximumThinkingSpinner =
+            {
+                Message = "Maximum thinking!!!"
+                Look = Some { calmLook with Color = Some Color.Red }
+                Spinner = Some Spinner.Known.Balloon2 }
+
+        let asyncProcess (context: StatusContext) =
+            async {
+                do! Async.Sleep 500
+
                 updateWithCustomSpinner harderThinkingSpinner context |> ignore
 
-                do! Task.Delay(3000)
-                let maximumThinkingSpinner =
-                    {
-                        Message = "Maximum thinking!!!"
-                        Look = Some { calmLook with Color = Some Color.Red }
-                        Spinner = Some Spinner.Known.Balloon2 }
+                do! Async.Sleep 500
                 updateWithCustomSpinner maximumThinkingSpinner context |> ignore
 
-                do! Task.Delay(3000)
+                do! Async.Sleep 200
+                return "42"
             }
-
-        (startWithCustomSpinner normalThinkingSpinner thinkingProcess).Wait()
-        P "No result" |> toConsole
+        let f = (Status.start "Meaning of Life" asyncProcess)
+        "Operation ready, press any key to start" |> C |> toConsole
+        Console.ReadLine () |> ignore
+        f
+        |> Async.RunSynchronously
+        |> P
+        |> toConsole
         0

--- a/src/spectrecoff-cli/commands/Status.fs
+++ b/src/spectrecoff-cli/commands/Status.fs
@@ -19,9 +19,9 @@ type StatusExample() =
               Look = Some { calmLook with Color = Some Color.Green } }
 
         let harderThinkingSpinner =
-                   { normalThinkingSpinner with
-                       Message = "Thinking harder..."
-                       Look = Some { calmLook with Color = Some Color.DarkOrange } }
+           { normalThinkingSpinner with
+               Message = "Thinking harder..."
+               Look = Some { calmLook with Color = Some Color.DarkOrange } }
 
         let maximumThinkingSpinner =
             {


### PR DESCRIPTION
- support `Async` for status widget 
- support generic result for status widget (for `Task` and `Async`)