### PR TITLE
Fixed typos in documentation

### DIFF
--- a/docs/modules.md
+++ b/docs/modules.md
@@ -1,7 +1,7 @@
 # SpectreCoff modules
 
 ## Modules from Spectre.Console
-_SpectreCoff_ is in feature-parity with _Spectre.Console_ nad also includes functionality of Dumpify. In the following table you can see the module mapping, as well as links to the corresponding documentation.
+_SpectreCoff_ is in feature-parity with _Spectre.Console_ and also includes functionality of Dumpify. In the following table you can see the module mapping, as well as links to the corresponding documentation.
 
 | SpectreCoff module                                      | Spectre.Console feature                                                       | 
 |---------------------------------------------------------|-------------------------------------------------------------------------------|

--- a/docs/modules/canvasimage.md
+++ b/docs/modules/canvasimage.md
@@ -1,7 +1,7 @@
 # CanvasImage Module
 This module provides functionality from the [canvas image widget](https://spectreconsole.net/widgets/canvas-image) of _Spectre.Console_.
 
-The canvas image can be created using the canvasImage function,"
+The canvas image can be created using the `canvasImage` function,
 ```fs
 canvasImage: ImageSource -> CanvasImage
 ```
@@ -17,7 +17,7 @@ The canvas image module exposes the mutable variable `maxWidth` (with a default 
 
 Same as in _Spectre.Console_, the [ImageSharp](https://github.com/SixLabors/ImageSharp) api can be used to transform the created images.
 
-Finally, the canvasImage can be mapped to an `OutputPayload` using `toOutputPayload` and be sent to the console via the `toConsole` function.
+Finally, the `CanvasImage` can be mapped to an `OutputPayload` using `toOutputPayload` and be sent to the console via the `toConsole` function.
 
 ### Example
 ```fs

--- a/docs/modules/chart.md
+++ b/docs/modules/chart.md
@@ -14,7 +14,7 @@ This variable can be overwritten with a custom set if the default one is not to 
 ## BarChart Module
 This module provides functionality from the [bar chart widget](https://spectreconsole.net/widgets/barchart) of Spectre.Console.
 
-The bar chart can be used using the barChart function:
+The bar chart can be used using the `barChart` function:
 ```fs
 barChart: string -> ChartItem list -> OutputPayload
 ```
@@ -26,7 +26,7 @@ module BarChart =
     let mutable alignment = Center      // Determines the alignment of the chart's label
 ```
 
-Finally, the chart is sent to the consolevia the `toConsole` function.
+Finally, the chart is sent to the console via the `toConsole` function.
 
 ### Example
 ```fs
@@ -51,7 +51,7 @@ dotnet run barchart example
 ## BreakdownChart Module
 This module provides functionality from the [breakdown chart widget](https://spectreconsole.net/widgets/breakdownchart) of Spectre.Console.
 
-The breakdown chart can be used using the breakdownChart function:
+The breakdown chart can be used using the `breakdownChart` function:
 ```fs
 breakdownChart: string -> ChartItem list -> OutputPayload
 ```
@@ -62,7 +62,7 @@ module BreakdownChart =
     let mutable width = 60
 ```
 
-Finally, the chart is sent to the consolevia the `toConsole` function.
+Finally, the chart is sent to the console via the `toConsole` function.
 
 ### Example
 ```fs

--- a/docs/modules/figlet.md
+++ b/docs/modules/figlet.md
@@ -15,7 +15,7 @@ module SpectreCoff.Figlet
 ```
 while the `customFiglet` function accepts corresponding values and does not use the defaults.
 
-Finally, the figlet is sent to the consolevia the `toConsole` function.
+Finally, the figlet is sent to the console via the `toConsole` function.
 
 ### Example
 ```fs

--- a/docs/modules/grid.md
+++ b/docs/modules/grid.md
@@ -1,7 +1,7 @@
 # Grid Module
 This module provides functionality from the [grid widget](https://spectreconsole.net/widgets/grid) of _Spectre.Console_.
 
-The grid can be created using:,
+The grid can be created using:
 ```fs
 grid: Row list -> Grid
 ```

--- a/docs/modules/json.md
+++ b/docs/modules/json.md
@@ -56,7 +56,7 @@ module SpectreCoff.Json
           Decorations = [ Decoration.Dim ] }
 ```
 
-Finally, the figlet is sent to the consolevia the `toConsole` function.
+Finally, the figlet is sent to the console via the `toConsole` function.
 
 ### Example
 ```fs

--- a/docs/modules/livedisplay.md
+++ b/docs/modules/livedisplay.md
@@ -21,7 +21,7 @@ let mutable defaultConfiguration: LiveDisplayConfiguration =
 ```
 
 ### Example
-This example simulates computing squares and cuebs of numbers on a really (!) slow computer:
+This example simulates computing squares and cubes of numbers on a really (!) slow computer:
 ```fs
 // Define some columns for the table
 let columns = [

--- a/docs/modules/panel.md
+++ b/docs/modules/panel.md
@@ -18,7 +18,7 @@ let mutable defaultPanelLayout: PanelLayout =
 ```
 while any other instance of that type can be passed in the `customPanel` function.
 
-Finally, the panel is sent to the consolevia the `toConsole` function.
+Finally, the panel is sent to the console via the `toConsole` function.
 
 ### Example
 ```fs

--- a/docs/modules/progress.md
+++ b/docs/modules/progress.md
@@ -26,7 +26,7 @@ let mutable defaultTemplate =
     |> withProgressBarColumn
     |> withPercentageColumn
 ```
-All builder funtions have the signature `ProcessTemplate -> ProcessTemplate`. There are two more ones besides teh ones used in the default template: `withRemainingTimeColumn`, `withSpinnerColumn`.
+All builder functions have the signature `ProcessTemplate -> ProcessTemplate`. There are two more ones besides the ones used in the default template: `withRemainingTimeColumn`, `withSpinnerColumn`.
 
 Inside the passed ProgressOperation, _tasks_ can be added to the `ProgressContext` using the `realizeIn` function:
 ```fs

--- a/docs/modules/table.md
+++ b/docs/modules/table.md
@@ -35,7 +35,7 @@ let mutable defaultColumnLayout: ColumnLayout =
       Wrap = true }
 ```
 
-The colum definition can be creted manually, or with these pipable builder functions:
+The column definition can be created manually, or with these pipeable builder functions:
 ```fs
 column: OutputPayload -> ColumDefinition
 withFooter: OutputPayload -> ColumnDefinition -> ColumnDefinition
@@ -44,7 +44,7 @@ withFooters: OutputPayload list -> ColumnDefinition list -> ColumnDefinition lis
 withSameLayout: ColumnLayout -> ColumnDefinition list -> ColumnDefinition list
 ```
 
-The data of the table is provided by instances of the `Row` type, which is the same type as the one used in the [Grid module](Grid.md). Rows can also be added after creation, using:
+The data of the table is provided by instances of the `Row` type, which is the same type as the one used in the [Grid module](grid.md). Rows can also be added after creation, using:
 ```fs
 addRowToTable: table -> row -> unit
 ```


### PR DESCRIPTION
I noticed some squigglies when opening the files with neovim ...