### PR TITLE
Migrate Status module from Async to Task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,6 @@ Changelog entries are grouped by `major.minor`. If you are on a specific `0.x.y`
 
 #### `Table`: `withLayouts` and `withFooters` parameter types corrected
 The inferred types of the parameters were swapped due to incorrect tuple destructuring. Any call site that relied on the (broken) swapped types will need to be updated to pass `layouts: ColumnLayout list` and `columns: ColumnDefinition list` in the correct order.
+
+#### `Status`: `StatusOperation` changed from `Async`-based to `Task`-based
+`StatusOperation<'Result>` is now `StatusContext -> Task<'Result>` (was `StatusContext -> Async<'Result>`). `start` and `startWithCustomSpinner` now return `Task<'Result>`. Update operation lambdas from `async { }` to `task { }` and `Async.Sleep` to `Task.Delay`.

--- a/src/spectrecoff-cli/commands/Status.fs
+++ b/src/spectrecoff-cli/commands/Status.fs
@@ -1,6 +1,7 @@
 namespace SpectreCoff.Cli.Commands
 
 open System
+open System.Threading.Tasks
 open Spectre.Console
 open Spectre.Console.Cli
 open SpectreCoff
@@ -30,21 +31,21 @@ type StatusExample() =
                 Spinner = Some Spinner.Known.Balloon2 }
 
         let asyncProcess (context: StatusContext) =
-            async {
-                do! Async.Sleep 500
+            task {
+                do! Task.Delay 500
 
                 updateWithCustomSpinner harderThinkingSpinner context |> ignore
 
-                do! Async.Sleep 500
+                do! Task.Delay 500
                 updateWithCustomSpinner maximumThinkingSpinner context |> ignore
 
-                do! Async.Sleep 200
+                do! Task.Delay 200
                 return "42"
             }
-        let f = (Status.start "Meaning of Life" asyncProcess)
-        "Operation ready, press any key to start" |> C |> toConsole
+        "Press any key to start" |> C |> toConsole
         Console.ReadLine () |> ignore
-        f
+        Status.start "Meaning of Life" asyncProcess
+        |> Async.AwaitTask
         |> Async.RunSynchronously
         |> P
         |> toConsole

--- a/src/spectrecoff/Spectre/Status.fs
+++ b/src/spectrecoff/Spectre/Status.fs
@@ -1,6 +1,7 @@
 ﻿[<AutoOpen>]
 module SpectreCoff.Status
 
+open System.Threading.Tasks
 open Spectre.Console
 
 type CustomSpinner =
@@ -8,7 +9,7 @@ type CustomSpinner =
       Spinner: Spinner Option
       Look: Look Option }
 
-type StatusOperation<'Result> = StatusContext -> Async<'Result>
+type StatusOperation<'Result> = StatusContext -> Task<'Result>
 
 let private configureStatus spinner (status: Status) =
     status.Spinner <-
@@ -39,21 +40,14 @@ let updateWithCustomSpinner spinner (context: StatusContext) =
     context
 
 let start<'Result> statusText (operation: StatusOperation<'Result>) =
-    async {
-        return!
-            AnsiConsole
-                .Status()
-                .StartAsync(statusText, (fun context -> operation context |> Async.StartAsTask))
-            |> Async.AwaitTask
-    }
+    AnsiConsole
+        .Status()
+        .StartAsync(statusText, operation)
 
 let startWithCustomSpinner<'Result> spinner (operation: StatusOperation<'Result>) =
-    async {
-        let status = AnsiConsole.Status() |> configureStatus spinner
-        return!
-            status.StartAsync(spinner.Message, fun context -> operation context |> Async.StartAsTask)
-            |> Async.AwaitTask
-    }
+    AnsiConsole.Status()
+    |> configureStatus spinner
+    |> fun status -> status.StartAsync(spinner.Message, operation)
 
 let update newMessage (context: StatusContext) =
     context.Status <- newMessage


### PR DESCRIPTION
Aligns with Progress module and Spectre.Console's native Task-based API, removing the Async.StartAsTask/Async.AwaitTask bridging that was needed before.